### PR TITLE
Fix :bug: with ls [keyword]

### DIFF
--- a/src/main/java/nus/climods/model/module/CodeContainsKeywordsPredicate.java
+++ b/src/main/java/nus/climods/model/module/CodeContainsKeywordsPredicate.java
@@ -22,7 +22,7 @@ public class CodeContainsKeywordsPredicate implements Predicate<Module> {
     @Override
     public boolean test(Module module) {
         if (facultyCode.isPresent()) {
-            Pattern facultyCodeRegex = Pattern.compile(String.format("(?i)%s\\d{4}$", facultyCode.get()));
+            Pattern facultyCodeRegex = Pattern.compile(String.format("^(?i)%s\\d{4}$", facultyCode.get()));
             return facultyCodeRegex.matcher(module.getCode()).find();
         }
         return true;


### PR DESCRIPTION
Prev keyword was not matched from the start of the module code, resulting in a bug where `ls st` returned `bfs` and `tfs` modules.

This has been fixed