### PR TITLE
Better sort order for `find` results

### DIFF
--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -47,7 +47,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-
     public ReadOnlyModuleList getModuleList() {
         return model.getModuleList();
     }

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -36,7 +36,7 @@ public class DeleteCommand extends Command {
 
         UserModule toDelete = new UserModule(targetCode, model);
 
-        if (!model.filteredListhasUserModule(toDelete)) {
+        if (!model.filteredListHasUserModule(toDelete)) {
             return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode));
         }
 

--- a/src/main/java/nus/climods/logic/commands/FindCommand.java
+++ b/src/main/java/nus/climods/logic/commands/FindCommand.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import nus.climods.commons.core.Messages;
 import nus.climods.model.Model;
+import nus.climods.model.module.comparator.ModuleBestMatchKeywordComparator;
 import nus.climods.model.module.predicate.ModuleContainsKeywordsPredicate;
 
 /**
@@ -34,7 +35,8 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setFilteredModuleList(new ModuleContainsKeywordsPredicate(searchRegexes));
+        model.setFilteredModuleList(new ModuleContainsKeywordsPredicate(searchRegexes),
+            new ModuleBestMatchKeywordComparator(searchRegexes));
 
         return new CommandResult(
             String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, model.getFilteredModuleList().size()));

--- a/src/main/java/nus/climods/logic/commands/ListCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ListCommand.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import nus.climods.logic.parser.parameters.FacultyCodeParameter;
 import nus.climods.logic.parser.parameters.UserFlagParameter;
 import nus.climods.model.Model;
-import nus.climods.model.module.CodeContainsKeywordsPredicate;
+import nus.climods.model.module.predicate.CodeContainsKeywordsPredicate;
 
 /**
  * Lists all modules in NUS to the user.

--- a/src/main/java/nus/climods/logic/commands/ListCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ListCommand.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import nus.climods.logic.parser.parameters.FacultyCodeParameter;
 import nus.climods.logic.parser.parameters.UserFlagParameter;
 import nus.climods.model.Model;
+import nus.climods.model.module.CodeContainsKeywordsPredicate;
 
 /**
  * Lists all modules in NUS to the user.
@@ -26,8 +27,9 @@ public class ListCommand extends Command {
 
     /**
      * Used for list command containing predicates
+     *
      * @param faculty optional argument to specify the faculty
-     * @param faculty
+     * @param hasUser
      */
     public ListCommand(FacultyCodeParameter faculty, UserFlagParameter hasUser) {
         this.facultyCode = faculty.getOptionalArgValue();
@@ -37,7 +39,10 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredModuleList(facultyCode, hasUser);
+        // TODO: Implement filtering for saved modules
+        // Support for --user flag
+        model.setFilteredModuleList(new CodeContainsKeywordsPredicate(facultyCode));
+
         return new CommandResult(String.format(MESSAGE_MODULES_LISTED_OVERVIEW,
                 model.getFilteredModuleList().size()));
     }

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -1,6 +1,6 @@
 package nus.climods.model;
 
-import java.util.Optional;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -19,6 +19,8 @@ public interface Model {
      */
     Predicate<UserModule> PREDICATE_SHOW_ALL_MODULES = unused -> true;
 
+    //=========== UserPrefs ==================================================================================
+
     /**
      * Returns the user prefs.
      */
@@ -29,6 +31,8 @@ public interface Model {
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);
 
+    //=========== GuiSettings ==================================================================================
+
     /**
      * Returns the user prefs' GUI settings.
      */
@@ -38,9 +42,18 @@ public interface Model {
      * Sets the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    //=========== Module ==================================================================================
+
     ReadOnlyModuleList getModuleList();
 
-    /* USER MODULE */
+    ObservableList<Module> getFilteredModuleList();
+
+    void setFilteredModuleList(Predicate<Module> predicate);
+
+    void setFilteredModuleList(Predicate<Module> predicate, Comparator<Module> comparator);
+
+    //=========== UserModule ==================================================================================
 
     /**
      * Returns true if a module with the same identity as {@code module} exists in the address book.
@@ -50,8 +63,7 @@ public interface Model {
     /**
      * Returns true if a module with the same identity as {@code module} exists in the filtered user module list
      */
-    boolean filteredListhasUserModule(UserModule module);
-
+    boolean filteredListHasUserModule(UserModule module);
 
     /**
      * Deletes the given module. The module must exist in the address book.
@@ -67,15 +79,11 @@ public interface Model {
      * Returns an unmodifiable view of the filtered module list
      */
     ObservableList<UserModule> getFilteredUserModuleList();
+
     /**
      * Updates the filter of the filtered module list to filter by the given {@code predicate}.
      *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredUserModuleList(Predicate<UserModule> predicate);
-    void updateFilteredModuleList(Optional<String> facultyCode, Optional<Boolean> hasUser);
-
-    ObservableList<Module> getFilteredModuleList();
-
-    void setFilteredModuleList(Predicate<Module> predicate);
 }

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -3,15 +3,15 @@ package nus.climods.model;
 import static java.util.Objects.requireNonNull;
 import static nus.climods.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Optional;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.commons.core.LogsCenter;
-import nus.climods.model.module.CodeContainsKeywordsPredicate;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ModuleList;
 import nus.climods.model.module.ReadOnlyModuleList;
@@ -23,17 +23,22 @@ import nus.climods.model.module.UserModule;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
-    private final ModuleList moduleList;
-    private final UniqueUserModuleList uniqueUserModuleList;
 
-    private final FilteredList<UserModule> filteredUserModules;
-    private final UserPrefs userPrefs;
+    private final ModuleList moduleList;
+    private final UniqueUserModuleList userModuleList;
+
     private final FilteredList<Module> filteredModuleList;
+    private final SortedList<Module> filteredAndSortedModuleList;
+    private final Comparator<? super Module> defaultModuleListComparator;
+
+    private final FilteredList<UserModule> filteredUserModuleList;
+
+    private final UserPrefs userPrefs;
 
     /**
      * Initializes a ModelManager with the given moduleList and userPrefs.
      */
-    public ModelManager(ReadOnlyModuleList moduleList, UniqueUserModuleList uniqueUserModuleList,
+    public ModelManager(ReadOnlyModuleList moduleList, UniqueUserModuleList userModuleList,
                         ReadOnlyUserPrefs userPrefs) {
         requireAllNonNull(moduleList, userPrefs);
 
@@ -41,46 +46,79 @@ public class ModelManager implements Model {
 
         this.userPrefs = new UserPrefs(userPrefs);
         this.moduleList = new ModuleList(moduleList);
-        this.uniqueUserModuleList = uniqueUserModuleList;
+        this.userModuleList = userModuleList;
+
         this.filteredModuleList = new FilteredList<>(moduleList.getModules());
-        filteredUserModules = new FilteredList<UserModule>(uniqueUserModuleList.asUnmodifiableObservableList());
+        this.filteredAndSortedModuleList = new SortedList<>(filteredModuleList);
+        this.defaultModuleListComparator = filteredAndSortedModuleList.getComparator();
+
+        this.filteredUserModuleList = new FilteredList<>(userModuleList.asUnmodifiableObservableList());
+    }
+
+    //=========== Module ==================================================================================
+
+    @Override
+    public ReadOnlyModuleList getModuleList() {
+        return moduleList;
+    }
+
+    @Override
+    public ObservableList<Module> getFilteredModuleList() {
+        return filteredAndSortedModuleList;
+    }
+
+    @Override
+    public void setFilteredModuleList(Predicate<Module> predicate) {
+        requireNonNull(predicate);
+        this.filteredModuleList.setPredicate(predicate);
+        // Reset to default comparator
+        this.filteredAndSortedModuleList.setComparator(defaultModuleListComparator);
+    }
+
+    @Override
+    public void setFilteredModuleList(Predicate<Module> predicate, Comparator<Module> comparator) {
+        setFilteredModuleList(predicate);
+
+        requireNonNull(comparator);
+        this.filteredAndSortedModuleList.setComparator(comparator);
     }
 
     //=========== UserModule ==================================================================================
 
     @Override
-    public boolean hasUserModule(UserModule module) {
-        requireNonNull(module);
-        return uniqueUserModuleList.contains(module);
-    }
-
-    @Override
-    public boolean filteredListhasUserModule(UserModule module) {
-        return this.getFilteredUserModuleList().contains(module);
+    public void addUserModule(UserModule module) {
+        userModuleList.add(module);
     }
 
     @Override
     public void deleteUserModule(UserModule target) {
         requireNonNull(target);
-        uniqueUserModuleList.remove(target);
+        userModuleList.remove(target);
     }
 
     @Override
-    public void addUserModule(UserModule module) {
-        uniqueUserModuleList.add(module);
-
+    public boolean hasUserModule(UserModule module) {
+        requireNonNull(module);
+        return userModuleList.contains(module);
     }
 
     @Override
     public ObservableList<UserModule> getFilteredUserModuleList() {
-        return filteredUserModules;
+        return filteredUserModuleList;
+    }
+
+    @Override
+    public boolean filteredListHasUserModule(UserModule module) {
+        return this.getFilteredUserModuleList().contains(module);
     }
 
     @Override
     public void updateFilteredUserModuleList(Predicate<UserModule> predicate) {
         requireNonNull(predicate);
-        filteredUserModules.setPredicate(predicate);
+        this.filteredUserModuleList.setPredicate(predicate);
     }
+
+    //=========== UserPrefs ==================================================================================
 
     @Override
     public ReadOnlyUserPrefs getUserPrefs() {
@@ -93,16 +131,7 @@ public class ModelManager implements Model {
         this.userPrefs.resetData(userPrefs);
     }
 
-    /**
-     * Filter the list by faculty Code
-     *
-     * @return
-     */
-    public void updateFilteredModuleList(Optional<String> facultyCode, Optional<Boolean> hasUser) {
-        // TODO: Implement filtering for saved modules
-        CodeContainsKeywordsPredicate predicate = new CodeContainsKeywordsPredicate(facultyCode);
-        filteredModuleList.setPredicate(predicate);
-    }
+    //=========== GuiSettings ==================================================================================
 
     @Override
     public GuiSettings getGuiSettings() {
@@ -113,22 +142,5 @@ public class ModelManager implements Model {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);
-    }
-
-    @Override
-    public ReadOnlyModuleList getModuleList() {
-        return moduleList;
-    }
-
-    @Override
-    public ObservableList<Module> getFilteredModuleList() {
-        return filteredModuleList;
-
-
-    }
-
-    public void setFilteredModuleList(Predicate<Module> predicate) {
-        requireNonNull(predicate);
-        this.filteredModuleList.setPredicate(predicate);
     }
 }

--- a/src/main/java/nus/climods/model/module/comparator/ModuleBestMatchKeywordComparator.java
+++ b/src/main/java/nus/climods/model/module/comparator/ModuleBestMatchKeywordComparator.java
@@ -1,0 +1,37 @@
+package nus.climods.model.module.comparator;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import nus.climods.model.module.Module;
+
+/**
+ * A comparator to sort modules based on keyword matches
+ */
+public class ModuleBestMatchKeywordComparator implements Comparator<Module> {
+
+    private final List<Pattern> searchRegexes;
+
+    public ModuleBestMatchKeywordComparator(List<Pattern> searchRegexes) {
+        this.searchRegexes = searchRegexes;
+    }
+
+    private long getKeywordNumMatches(Module module) {
+        return searchRegexes.stream().filter(module::containsKeyword).count();
+    }
+
+    /**
+     * Compares its two modules for order. Returns a negative integer, zero, or a positive integer as the first module
+     * has more matches than the second, equal matches, or the first module has fewer matches than the second.
+     *
+     * @param o1 first module
+     * @param o2 second module
+     * @return a negative integer, zero, or a positive integer as the first module has more matches than the second,
+     *         equal matches, or the first module has fewer matches than the second.
+     */
+    @Override
+    public int compare(Module o1, Module o2) {
+        return Long.compare(getKeywordNumMatches(o2), getKeywordNumMatches(o1));
+    }
+}

--- a/src/main/java/nus/climods/model/module/predicate/CodeContainsKeywordsPredicate.java
+++ b/src/main/java/nus/climods/model/module/predicate/CodeContainsKeywordsPredicate.java
@@ -1,8 +1,10 @@
-package nus.climods.model.module;
+package nus.climods.model.module.predicate;
 
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+
+import nus.climods.model.module.Module;
 
 /**
  * Tests that a {@code Module}'s {@code Module Code} matches any of the keywords given.

--- a/src/test/java/nus/climods/logic/commands/FindCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/FindCommandTest.java
@@ -60,6 +60,14 @@ class FindCommandTest {
             Arrays.asList("CS2100", "CS2101", "CS2102", "CS2103"));
     }
 
+    @Test
+    public void execute_regexKeywords_correctSortOrder() {
+        FindCommand command = new FindCommand(prepareSearchRegexes("software engineering"));
+        command.execute(model);
+
+        assertEquals(model.getFilteredModuleList().get(0).getCode(), "CS2103");
+    }
+
     /**
      * Parses {@code userInput} into a search regexes.
      */

--- a/src/test/java/nus/climods/logic/commands/ModelStub.java
+++ b/src/test/java/nus/climods/logic/commands/ModelStub.java
@@ -1,6 +1,6 @@
 package nus.climods.logic.commands;
 
-import java.util.Optional;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -54,7 +54,7 @@ class ModelStub implements Model {
     }
 
     @Override
-    public boolean filteredListhasUserModule(UserModule module) {
+    public boolean filteredListHasUserModule(UserModule module) {
         return hasModule;
     }
 
@@ -78,17 +78,17 @@ class ModelStub implements Model {
     }
 
     @Override
-    public void updateFilteredModuleList(Optional<String> facultyCode, Optional<Boolean> hasUser) {
-
-    }
-
-    @Override
     public ObservableList<Module> getFilteredModuleList() {
         return null;
     }
 
     @Override
     public void setFilteredModuleList(Predicate<Module> predicate) {
+
+    }
+
+    @Override
+    public void setFilteredModuleList(Predicate<Module> predicate, Comparator<Module> comparator) {
 
     }
 }


### PR DESCRIPTION
## Description

- Add support to `sort` module list via a `Comparator`
- Better ordering of `find` results
    - Example: When searching for "software engineering" more relevant modules will appear at the top of the list (see below)

**Now**
<img width="2672" alt="image" src="https://user-images.githubusercontent.com/47914880/196219933-2eee385b-3130-4f88-8610-3c222bf44355.png">

**Before**
<img width="2672" alt="image" src="https://user-images.githubusercontent.com/47914880/196220031-e43a02d3-b06d-4a83-a988-45edde0c4d95.png">

Note how by virtue of sorting it by the number matches to the search keywords, we get a better sort order of modules
 