### PR TITLE
 Implement storage for UserModuleList and support storage of add and delete

### DIFF
--- a/src/main/java/nus/climods/MainApp.java
+++ b/src/main/java/nus/climods/MainApp.java
@@ -59,7 +59,8 @@ public class MainApp extends Application {
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
 
         JsonUserModuleListStorage userModuleListStorage = new JsonUserModuleListStorage(userPrefs
-                .getUserModuleListFilePath());
+                    .getUserModuleListFilePath());
+
         // TODO: Update path to Module Model's path
         ModuleListStorage moduleListStorage = new JsonModuleListStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(moduleListStorage, userModuleListStorage, userPrefsStorage);
@@ -77,7 +78,7 @@ public class MainApp extends Application {
      * empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs)
-            throws IOException, DataConversionException {
+            throws IOException {
         Optional<ReadOnlyModuleList> moduleListOptional;
         ReadOnlyModuleList initialModuleList;
         Optional<UniqueUserModuleList> userModuleListOptional;
@@ -92,6 +93,9 @@ public class MainApp extends Application {
             initialUserModuleList = userModuleListOptional.get();
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format!");
+        } catch (NullPointerException e) {
+            logger.warning("Data file is empty!");
+        } finally {
             initialUserModuleList = new UniqueUserModuleList();
         }
 
@@ -105,8 +109,6 @@ public class MainApp extends Application {
             logger.warning("Data file not in the correct format!");
             initialModuleList = new ModuleList(academicYear);
         }
-
-
 
         return new ModelManager(initialModuleList, initialUserModuleList, userPrefs);
     }

--- a/src/main/java/nus/climods/MainApp.java
+++ b/src/main/java/nus/climods/MainApp.java
@@ -60,7 +60,8 @@ public class MainApp extends Application {
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
 
         // TODO Change userPref file path getters
-        UserModuleListStorage userModuleListStorage = new JsonUserModuleListStorage(userPrefs.getAddressBookFilePath());
+        UserModuleListStorage userModuleListStorage = new JsonUserModuleListStorage(userPrefs.getAddressBookFilePath(),
+                model);
         ModuleListStorage moduleListStorage = new JsonModuleListStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(moduleListStorage, userModuleListStorage, userPrefsStorage);
 

--- a/src/main/java/nus/climods/MainApp.java
+++ b/src/main/java/nus/climods/MainApp.java
@@ -59,9 +59,9 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
 
-        // TODO Change userPref file path getters
-        UserModuleListStorage userModuleListStorage = new JsonUserModuleListStorage(userPrefs.getAddressBookFilePath(),
-                model);
+        UserModuleListStorage userModuleListStorage = new JsonUserModuleListStorage(userPrefs
+                .getUserModuleListFilePath(), model);
+        // TODO: Update path to Module Model's path
         ModuleListStorage moduleListStorage = new JsonModuleListStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(moduleListStorage, userModuleListStorage, userPrefsStorage);
 

--- a/src/main/java/nus/climods/MainApp.java
+++ b/src/main/java/nus/climods/MainApp.java
@@ -89,13 +89,15 @@ public class MainApp extends Application {
             userModuleListOptional = storage.getUserModuleListStorage().readUserModuleList();
             if (userModuleListOptional.isEmpty()) {
                 logger.info("Data file not found!");
+                initialUserModuleList = new UniqueUserModuleList();
+            } else {
+                initialUserModuleList = userModuleListOptional.get();
             }
-            initialUserModuleList = userModuleListOptional.get();
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format!");
+            initialUserModuleList = new UniqueUserModuleList();
         } catch (NullPointerException e) {
             logger.warning("Data file is empty!");
-        } finally {
             initialUserModuleList = new UniqueUserModuleList();
         }
 

--- a/src/main/java/nus/climods/logic/Logic.java
+++ b/src/main/java/nus/climods/logic/Logic.java
@@ -1,7 +1,5 @@
 package nus.climods.logic;
 
-import java.io.IOException;
-
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.logic.commands.CommandResult;
@@ -10,6 +8,7 @@ import nus.climods.logic.parser.exceptions.ParseException;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UserModule;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * API of the Logic component
@@ -24,7 +23,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException   If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException, IOException;
+    CommandResult execute(String commandText) throws CommandException, ParseException, StorageException;
     ReadOnlyModuleList getModuleList();
     ObservableList<UserModule> getFilteredUserModuleList();
     ObservableList<Module> getFilteredModuleList();

--- a/src/main/java/nus/climods/logic/Logic.java
+++ b/src/main/java/nus/climods/logic/Logic.java
@@ -9,6 +9,8 @@ import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UserModule;
 
+import java.io.IOException;
+
 /**
  * API of the Logic component
  */
@@ -22,7 +24,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException   If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText) throws CommandException, ParseException, IOException;
     ReadOnlyModuleList getModuleList();
     ObservableList<UserModule> getFilteredUserModuleList();
     ObservableList<Module> getFilteredModuleList();

--- a/src/main/java/nus/climods/logic/Logic.java
+++ b/src/main/java/nus/climods/logic/Logic.java
@@ -1,5 +1,7 @@
 package nus.climods.logic;
 
+import java.io.IOException;
+
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.logic.commands.CommandResult;
@@ -8,8 +10,6 @@ import nus.climods.logic.parser.exceptions.ParseException;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UserModule;
-
-import java.io.IOException;
 
 /**
  * API of the Logic component

--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -36,14 +36,19 @@ public class LogicManager implements Logic {
         this.storage = storage;
     }
 
+    private void saveModuleList(boolean isSave) throws StorageException {
+        if (isSave) {
+            storage.saveUserModuleList(model.getUserModuleList());
+        }
+    }
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException, StorageException {
         logger.info("[User Command] " + commandText);
 
         CommandResult commandResult;
         Command command = CliModsParser.parseCommand(commandText);
-        commandResult = command.execute(model, storage);
-
+        commandResult = command.execute(model);
+        saveModuleList(commandResult.isSave());
         return commandResult;
     }
 

--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -5,10 +5,8 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.commons.core.LogsCenter;
-import nus.climods.logic.commands.AddCommand;
 import nus.climods.logic.commands.Command;
 import nus.climods.logic.commands.CommandResult;
-import nus.climods.logic.commands.DeleteCommand;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.CliModsParser;
 import nus.climods.logic.parser.exceptions.ParseException;
@@ -44,16 +42,8 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = CliModsParser.parseCommand(commandText);
-        commandResult = command.execute(model);
+        commandResult = command.execute(model, storage);
 
-        switch (command.getCommandWord()) {
-        case (AddCommand.COMMAND_WORD):
-
-        case (DeleteCommand.COMMAND_WORD):
-            storage.saveUserModuleList(model.getUserModuleList());
-            break;
-        default:
-        }
         return commandResult;
     }
 

--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -6,8 +6,10 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.commons.core.LogsCenter;
+import nus.climods.logic.commands.AddCommand;
 import nus.climods.logic.commands.Command;
 import nus.climods.logic.commands.CommandResult;
+import nus.climods.logic.commands.DeleteCommand;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.CliModsParser;
 import nus.climods.logic.parser.exceptions.ParseException;
@@ -43,8 +45,15 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = CliModsParser.parseCommand(commandText);
         commandResult = command.execute(model);
-        // TODO: Ideally only save after a successful add or delete
-        storage.saveUserModuleList(model.getUserModuleList());
+
+        switch (command.getCommandWord()) {
+        case (AddCommand.COMMAND_WORD):
+
+        case (DeleteCommand.COMMAND_WORD):
+            storage.saveUserModuleList(model.getUserModuleList());
+            break;
+        default:
+        }
         return commandResult;
     }
 

--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -1,5 +1,6 @@
 package nus.climods.logic;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -36,13 +37,14 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText) throws CommandException, ParseException, IOException {
         logger.info("[User Command] " + commandText);
 
         CommandResult commandResult;
         Command command = CliModsParser.parseCommand(commandText);
         commandResult = command.execute(model);
-
+        // TODO: Ideally only save after a successful add or delete
+        storage.saveUserModuleList(model.getUserModuleList());
         return commandResult;
     }
 

--- a/src/main/java/nus/climods/logic/LogicManager.java
+++ b/src/main/java/nus/climods/logic/LogicManager.java
@@ -1,6 +1,5 @@
 package nus.climods.logic;
 
-import java.io.IOException;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -18,6 +17,7 @@ import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UserModule;
 import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * The main LogicManager of the app.
@@ -39,7 +39,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException, IOException {
+    public CommandResult execute(String commandText) throws CommandException, ParseException, StorageException {
         logger.info("[User Command] " + commandText);
 
         CommandResult commandResult;

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -42,7 +42,7 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        UserModule moduleToAdd = new UserModule(model.getModule(toAdd));
+        UserModule moduleToAdd = new UserModule(model.getModule(toAdd.toUpperCase()));
 
         if (model.hasUserModule(moduleToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
@@ -50,7 +50,8 @@ public class AddCommand extends Command {
 
         model.addUserModule(moduleToAdd);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), COMMAND_WORD, model);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.toUpperCase()),
+                COMMAND_WORD, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -5,8 +5,6 @@ import static java.util.Objects.requireNonNull;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.module.UserModule;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Adds a person to the address book.
@@ -41,7 +39,7 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException, StorageException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
         UserModule moduleToAdd = new UserModule(model.getModule(toAdd));
@@ -52,7 +50,7 @@ public class AddCommand extends Command {
 
         model.addUserModule(moduleToAdd);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), COMMAND_WORD, storage, model);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), COMMAND_WORD, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -1,13 +1,9 @@
 package nus.climods.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static nus.climods.model.module.UserModule.MESSAGE_MODULE_NOT_FOUND;
-
-import java.util.Optional;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
-import nus.climods.model.module.Module;
 import nus.climods.model.module.UserModule;
 
 /**
@@ -42,20 +38,11 @@ public class AddCommand extends Command {
         toAdd = moduleCode;
     }
 
-    private Module getModule(Model model, String moduleCode) throws CommandException {
-        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
-
-        if (optionalModule.isEmpty()) {
-            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
-        }
-        return optionalModule.get();
-    }
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        UserModule moduleToAdd = new UserModule(getModule(model, toAdd));
+        UserModule moduleToAdd = new UserModule(model.getModule(toAdd));
 
         if (model.hasUserModule(moduleToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.module.UserModule;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Adds a person to the address book.
@@ -39,7 +41,7 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model, Storage storage) throws CommandException, StorageException {
         requireNonNull(model);
 
         UserModule moduleToAdd = new UserModule(model.getModule(toAdd));
@@ -50,12 +52,7 @@ public class AddCommand extends Command {
 
         model.addUserModule(moduleToAdd);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
-    }
-
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), COMMAND_WORD, storage, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -67,6 +67,11 @@ public class AddCommand extends Command {
     }
 
     @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof AddCommand // instanceof handles nulls

--- a/src/main/java/nus/climods/logic/commands/AddCommand.java
+++ b/src/main/java/nus/climods/logic/commands/AddCommand.java
@@ -1,9 +1,13 @@
 package nus.climods.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static nus.climods.model.module.UserModule.MESSAGE_MODULE_NOT_FOUND;
+
+import java.util.Optional;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
+import nus.climods.model.module.Module;
 import nus.climods.model.module.UserModule;
 
 /**
@@ -38,16 +42,27 @@ public class AddCommand extends Command {
         toAdd = moduleCode;
     }
 
+    private Module getModule(Model model, String moduleCode) throws CommandException {
+        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
+
+        if (optionalModule.isEmpty()) {
+            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
+        }
+        return optionalModule.get();
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        UserModule moduleToAdd = new UserModule(toAdd, model);
+
+        UserModule moduleToAdd = new UserModule(getModule(model, toAdd));
 
         if (model.hasUserModule(moduleToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
 
         model.addUserModule(moduleToAdd);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/nus/climods/logic/commands/Command.java
+++ b/src/main/java/nus/climods/logic/commands/Command.java
@@ -2,8 +2,6 @@ package nus.climods.logic.commands;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
@@ -17,5 +15,5 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model, Storage storage) throws CommandException, StorageException;
+    public abstract CommandResult execute(Model model) throws CommandException;
 }

--- a/src/main/java/nus/climods/logic/commands/Command.java
+++ b/src/main/java/nus/climods/logic/commands/Command.java
@@ -17,4 +17,7 @@ public abstract class Command {
      */
     public abstract CommandResult execute(Model model) throws CommandException;
 
+    public String getCommandWord() {
+        return null;
+    }
 }

--- a/src/main/java/nus/climods/logic/commands/Command.java
+++ b/src/main/java/nus/climods/logic/commands/Command.java
@@ -2,6 +2,8 @@ package nus.climods.logic.commands;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
@@ -15,9 +17,5 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model) throws CommandException;
-
-    public String getCommandWord() {
-        return null;
-    }
+    public abstract CommandResult execute(Model model, Storage storage) throws CommandException, StorageException;
 }

--- a/src/main/java/nus/climods/logic/commands/CommandResult.java
+++ b/src/main/java/nus/climods/logic/commands/CommandResult.java
@@ -5,8 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import nus.climods.model.Model;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Represents the result of a command execution.
@@ -24,6 +22,9 @@ public class CommandResult {
      */
     private final boolean exit;
 
+    /* The application should save userModuleList */
+    private boolean isSave;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -31,6 +32,7 @@ public class CommandResult {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        isSave = false;
     }
 
     /**
@@ -38,16 +40,17 @@ public class CommandResult {
      * default value.
      */
     public CommandResult(String feedbackToUser, String commandWord,
-                         Storage storage, Model model) throws StorageException {
+                         Model model) {
         this(feedbackToUser, false, false);
 
         switch (commandWord) {
         case (AddCommand.COMMAND_WORD):
 
         case (DeleteCommand.COMMAND_WORD):
-            storage.saveUserModuleList(model.getUserModuleList());
+            isSave = true;
             break;
         default:
+            isSave = false;
         }
     }
 
@@ -63,6 +66,8 @@ public class CommandResult {
         return exit;
     }
 
+    public boolean isSave() { return isSave; }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -76,8 +81,9 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-            && showHelp == otherCommandResult.showHelp
-            && exit == otherCommandResult.exit;
+            && showHelp == otherCommandResult.isShowHelp()
+            && exit == otherCommandResult.isExit()
+            && isSave == otherCommandResult.isSave();
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/CommandResult.java
+++ b/src/main/java/nus/climods/logic/commands/CommandResult.java
@@ -4,6 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import nus.climods.model.Model;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
+
 /**
  * Represents the result of a command execution.
  */
@@ -33,8 +37,18 @@ public class CommandResult {
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, and other fields set to their
      * default value.
      */
-    public CommandResult(String feedbackToUser) {
+    public CommandResult(String feedbackToUser, String commandWord,
+                         Storage storage, Model model) throws StorageException {
         this(feedbackToUser, false, false);
+
+        switch (commandWord) {
+        case (AddCommand.COMMAND_WORD):
+
+        case (DeleteCommand.COMMAND_WORD):
+            storage.saveUserModuleList(model.getUserModuleList());
+            break;
+        default:
+        }
     }
 
     public String getFeedbackToUser() {

--- a/src/main/java/nus/climods/logic/commands/CommandResult.java
+++ b/src/main/java/nus/climods/logic/commands/CommandResult.java
@@ -8,7 +8,6 @@ import java.util.Objects;
  * Represents the result of a command execution.
  */
 public class CommandResult {
-
     private final String feedbackToUser;
 
     /**
@@ -71,5 +70,4 @@ public class CommandResult {
     public int hashCode() {
         return Objects.hash(feedbackToUser, showHelp, exit);
     }
-
 }

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
-import nus.climods.model.module.UserModule;
+import nus.climods.model.module.exceptions.UserModuleNotFoundException;
 
 
 /**
@@ -34,15 +34,15 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
-        UserModule toDelete = new UserModule(model.getModule(targetCode));
-        if (!model.filteredListhasUserModule(toDelete)) {
-            return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode),
+        try {
+            model.deleteUserModule(targetCode);
+        } catch (UserModuleNotFoundException e) {
+            return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode.toUpperCase()),
                     COMMAND_WORD, model);
         }
 
-        model.deleteUserModule(toDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, targetCode), COMMAND_WORD, model);
+        return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, targetCode.toUpperCase()),
+                COMMAND_WORD, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -5,8 +5,6 @@ import static java.util.Objects.requireNonNull;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.module.UserModule;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 
 /**
@@ -34,17 +32,17 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException, StorageException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
         UserModule toDelete = new UserModule(model.getModule(targetCode));
         if (!model.filteredListhasUserModule(toDelete)) {
             return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode),
-                    COMMAND_WORD, storage, model);
+                    COMMAND_WORD, model);
         }
 
         model.deleteUserModule(toDelete);
-        return new CommandResult(MESSAGE_DELETE_MODULE_SUCCESS, COMMAND_WORD, storage, model);
+        return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, targetCode), COMMAND_WORD, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -58,6 +58,11 @@ public class DeleteCommand extends Command {
     }
 
     @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof DeleteCommand // instanceof handles nulls

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -1,10 +1,15 @@
 package nus.climods.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static nus.climods.model.module.UserModule.MESSAGE_MODULE_NOT_FOUND;
+
+import java.util.Optional;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
+import nus.climods.model.module.Module;
 import nus.climods.model.module.UserModule;
+
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -23,19 +28,27 @@ public class DeleteCommand extends Command {
 
     /**
      * Creates a DeleteCommand with the given UserModule
-     * @param target UserModule to delete
+     * @param targetCode module code of UserModule to delete
      */
     public DeleteCommand(String targetCode) {
         requireNonNull(targetCode);
         this.targetCode = targetCode;
     }
 
+    private Module getModule(Model model, String moduleCode) throws CommandException {
+        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
+
+        if (optionalModule.isEmpty()) {
+            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
+        }
+        return optionalModule.get();
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        UserModule toDelete = new UserModule(targetCode, model);
-
+        UserModule toDelete = new UserModule(getModule(model, targetCode));
         if (!model.filteredListhasUserModule(toDelete)) {
             return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode));
         }

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.module.UserModule;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 
 /**
@@ -32,21 +34,17 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model, Storage storage) throws CommandException, StorageException {
         requireNonNull(model);
 
         UserModule toDelete = new UserModule(model.getModule(targetCode));
         if (!model.filteredListhasUserModule(toDelete)) {
-            return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode));
+            return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode),
+                    COMMAND_WORD, storage, model);
         }
 
         model.deleteUserModule(toDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, targetCode));
-    }
-
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
+        return new CommandResult(MESSAGE_DELETE_MODULE_SUCCESS, COMMAND_WORD, storage, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/DeleteCommand.java
+++ b/src/main/java/nus/climods/logic/commands/DeleteCommand.java
@@ -1,13 +1,9 @@
 package nus.climods.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static nus.climods.model.module.UserModule.MESSAGE_MODULE_NOT_FOUND;
-
-import java.util.Optional;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
-import nus.climods.model.module.Module;
 import nus.climods.model.module.UserModule;
 
 
@@ -35,20 +31,11 @@ public class DeleteCommand extends Command {
         this.targetCode = targetCode;
     }
 
-    private Module getModule(Model model, String moduleCode) throws CommandException {
-        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
-
-        if (optionalModule.isEmpty()) {
-            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
-        }
-        return optionalModule.get();
-    }
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        UserModule toDelete = new UserModule(getModule(model, targetCode));
+        UserModule toDelete = new UserModule(model.getModule(targetCode));
         if (!model.filteredListhasUserModule(toDelete)) {
             return new CommandResult(String.format(MESSAGE_DELETE_MODULE_FAILED, targetCode));
         }

--- a/src/main/java/nus/climods/logic/commands/ExitCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ExitCommand.java
@@ -1,7 +1,6 @@
 package nus.climods.logic.commands;
 
 import nus.climods.model.Model;
-import nus.climods.storage.Storage;
 
 /**
  * Terminates the program.
@@ -22,7 +21,7 @@ public class ExitCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model mode, Storage storage) {
+    public CommandResult execute(Model mode) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 

--- a/src/main/java/nus/climods/logic/commands/ExitCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ExitCommand.java
@@ -1,6 +1,7 @@
 package nus.climods.logic.commands;
 
 import nus.climods.model.Model;
+import nus.climods.storage.Storage;
 
 /**
  * Terminates the program.
@@ -19,13 +20,10 @@ public class ExitCommand extends Command {
         return obj instanceof ExitCommand;
     }
 
+
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model mode, Storage storage) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/nus/climods/logic/commands/ExitCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ExitCommand.java
@@ -23,4 +23,9 @@ public class ExitCommand extends Command {
     public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/nus/climods/logic/commands/FindCommand.java
+++ b/src/main/java/nus/climods/logic/commands/FindCommand.java
@@ -9,8 +9,6 @@ import java.util.stream.Collectors;
 import nus.climods.commons.core.Messages;
 import nus.climods.model.Model;
 import nus.climods.model.module.predicate.ModuleContainsKeywordsPredicate;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Find a module using a search phrase
@@ -34,13 +32,13 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws StorageException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setFilteredModuleList(new ModuleContainsKeywordsPredicate(searchRegexes));
 
         return new CommandResult(
             String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, model.getFilteredModuleList().size()),
-                COMMAND_WORD, storage, model);
+                COMMAND_WORD, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/FindCommand.java
+++ b/src/main/java/nus/climods/logic/commands/FindCommand.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import nus.climods.commons.core.Messages;
 import nus.climods.model.Model;
 import nus.climods.model.module.predicate.ModuleContainsKeywordsPredicate;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Find a module using a search phrase
@@ -32,17 +34,13 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, Storage storage) throws StorageException {
         requireNonNull(model);
         model.setFilteredModuleList(new ModuleContainsKeywordsPredicate(searchRegexes));
 
         return new CommandResult(
-            String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, model.getFilteredModuleList().size()));
-    }
-
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
+            String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, model.getFilteredModuleList().size()),
+                COMMAND_WORD, storage, model);
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/FindCommand.java
+++ b/src/main/java/nus/climods/logic/commands/FindCommand.java
@@ -41,6 +41,11 @@ public class FindCommand extends Command {
     }
 
     @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this
             || (other instanceof FindCommand

--- a/src/main/java/nus/climods/logic/commands/HelpCommand.java
+++ b/src/main/java/nus/climods/logic/commands/HelpCommand.java
@@ -3,7 +3,6 @@ package nus.climods.logic.commands;
 import static nus.climods.commons.core.Messages.MESSAGE_SHOW_HELP;
 
 import nus.climods.model.Model;
-import nus.climods.storage.Storage;
 
 /**
  * Format full help instructions for every command for display.
@@ -17,7 +16,7 @@ public class HelpCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_SHOW_HELP, true, false);
     }
 

--- a/src/main/java/nus/climods/logic/commands/HelpCommand.java
+++ b/src/main/java/nus/climods/logic/commands/HelpCommand.java
@@ -3,6 +3,7 @@ package nus.climods.logic.commands;
 import static nus.climods.commons.core.Messages.MESSAGE_SHOW_HELP;
 
 import nus.climods.model.Model;
+import nus.climods.storage.Storage;
 
 /**
  * Format full help instructions for every command for display.
@@ -16,13 +17,8 @@ public class HelpCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, Storage storage) {
         return new CommandResult(MESSAGE_SHOW_HELP, true, false);
-    }
-
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
     }
 
     @Override

--- a/src/main/java/nus/climods/logic/commands/HelpCommand.java
+++ b/src/main/java/nus/climods/logic/commands/HelpCommand.java
@@ -21,6 +21,11 @@ public class HelpCommand extends Command {
     }
 
     @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other instanceof HelpCommand;
     }

--- a/src/main/java/nus/climods/logic/commands/ListCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ListCommand.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 import nus.climods.logic.parser.parameters.FacultyCodeParameter;
 import nus.climods.logic.parser.parameters.UserFlagParameter;
 import nus.climods.model.Model;
-import nus.climods.storage.Storage;
-import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Lists all modules in NUS to the user.
@@ -37,11 +35,11 @@ public class ListCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws StorageException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredModuleList(facultyCode, hasUser);
         return new CommandResult(String.format(MESSAGE_MODULES_LISTED_OVERVIEW,
                 model.getFilteredModuleList().size()),
-                COMMAND_WORD, storage, model);
+                COMMAND_WORD, model);
     }
 }

--- a/src/main/java/nus/climods/logic/commands/ListCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ListCommand.java
@@ -41,4 +41,9 @@ public class ListCommand extends Command {
         return new CommandResult(String.format(MESSAGE_MODULES_LISTED_OVERVIEW,
                 model.getFilteredModuleList().size()));
     }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/nus/climods/logic/commands/ListCommand.java
+++ b/src/main/java/nus/climods/logic/commands/ListCommand.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import nus.climods.logic.parser.parameters.FacultyCodeParameter;
 import nus.climods.logic.parser.parameters.UserFlagParameter;
 import nus.climods.model.Model;
+import nus.climods.storage.Storage;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * Lists all modules in NUS to the user.
@@ -35,15 +37,11 @@ public class ListCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, Storage storage) throws StorageException {
         requireNonNull(model);
         model.updateFilteredModuleList(facultyCode, hasUser);
         return new CommandResult(String.format(MESSAGE_MODULES_LISTED_OVERVIEW,
-                model.getFilteredModuleList().size()));
-    }
-
-    @Override
-    public String getCommandWord() {
-        return COMMAND_WORD;
+                model.getFilteredModuleList().size()),
+                COMMAND_WORD, storage, model);
     }
 }

--- a/src/main/java/nus/climods/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/nus/climods/logic/commands/exceptions/CommandException.java
@@ -10,7 +10,7 @@ public class CommandException extends Exception {
     }
 
     /**
-     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
+     * Constructs a new {@code StorageException} with the specified detail {@code message} and {@code cause}.
      */
     public CommandException(String message, Throwable cause) {
         super(message, cause);

--- a/src/main/java/nus/climods/logic/parser/AddCommandParser.java
+++ b/src/main/java/nus/climods/logic/parser/AddCommandParser.java
@@ -1,11 +1,8 @@
 package nus.climods.logic.parser;
 
 import nus.climods.logic.commands.AddCommand;
-import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
 import nus.climods.logic.parser.parameters.ModuleCodeParameter;
-import nus.climods.model.Model;
-
 
 /**
  * Parses input arguments and creates a new AddCommand object

--- a/src/main/java/nus/climods/logic/parser/AddCommandParser.java
+++ b/src/main/java/nus/climods/logic/parser/AddCommandParser.java
@@ -1,15 +1,16 @@
 package nus.climods.logic.parser;
 
 import nus.climods.logic.commands.AddCommand;
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
 import nus.climods.logic.parser.parameters.ModuleCodeParameter;
+import nus.climods.model.Model;
 
 
 /**
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand and returns an AddCommand object
      * for execution.

--- a/src/main/java/nus/climods/logic/parser/Parser.java
+++ b/src/main/java/nus/climods/logic/parser/Parser.java
@@ -1,7 +1,9 @@
 package nus.climods.logic.parser;
 
 import nus.climods.logic.commands.Command;
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
+import nus.climods.model.Model;
 
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.

--- a/src/main/java/nus/climods/logic/parser/Parser.java
+++ b/src/main/java/nus/climods/logic/parser/Parser.java
@@ -1,9 +1,7 @@
 package nus.climods.logic.parser;
 
 import nus.climods.logic.commands.Command;
-import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
-import nus.climods.model.Model;
 
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.

--- a/src/main/java/nus/climods/model/AddressBook.java
+++ b/src/main/java/nus/climods/model/AddressBook.java
@@ -134,7 +134,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Removes {@code key} from this {@code AddressBook}. {@code key} must exist in the address book.
      */
-    public void removeUserModule(UserModule key) {
+    public void removeUserModule(String key) {
         modules.remove(key);
     }
 

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -50,15 +50,9 @@ public interface Model {
     boolean hasUserModule(UserModule module);
 
     /**
-     * Returns true if a module with the same identity as {@code module} exists in the filtered user module list
+     * Deletes the given module code
      */
-    boolean filteredListhasUserModule(UserModule module);
-
-
-    /**
-     * Deletes the given module. The module must exist in the address book.
-     */
-    void deleteUserModule(UserModule target);
+    void deleteUserModule(String target);
 
     /**
      * Adds the given module. {@code module} must not already exist in the address book.

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
+import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
 
 
@@ -74,6 +75,8 @@ public interface Model {
      */
     void updateFilteredUserModuleList(Predicate<UserModule> predicate);
     void updateFilteredModuleList(Optional<String> facultyCode, Optional<Boolean> hasUser);
+
+    UniqueUserModuleList getUserModuleList();
 
     ObservableList<Module> getFilteredModuleList();
 

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
@@ -81,4 +82,6 @@ public interface Model {
     ObservableList<Module> getFilteredModuleList();
 
     void setFilteredModuleList(Predicate<Module> predicate);
+
+    Module getModule(String moduleCode) throws CommandException;
 }

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -57,12 +57,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean filteredListhasUserModule(UserModule module) {
-        return this.getFilteredUserModuleList().contains(module);
-    }
-
-    @Override
-    public void deleteUserModule(UserModule target) {
+    public void deleteUserModule(String target) {
         requireNonNull(target);
         uniqueUserModuleList.remove(target);
     }

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -2,6 +2,7 @@ package nus.climods.model;
 
 import static java.util.Objects.requireNonNull;
 import static nus.climods.commons.util.CollectionUtil.requireAllNonNull;
+import static nus.climods.model.module.UserModule.MESSAGE_MODULE_NOT_FOUND;
 
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -11,6 +12,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import nus.climods.commons.core.GuiSettings;
 import nus.climods.commons.core.LogsCenter;
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.module.CodeContainsKeywordsPredicate;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ModuleList;
@@ -135,5 +137,14 @@ public class ModelManager implements Model {
     public void setFilteredModuleList(Predicate<Module> predicate) {
         requireNonNull(predicate);
         this.filteredModuleList.setPredicate(predicate);
+    }
+
+    public Module getModule(String moduleCode) throws CommandException {
+        Optional<Module> optionalModule = moduleList.getListModule(moduleCode);
+
+        if (optionalModule.isEmpty()) {
+            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
+        }
+        return optionalModule.get();
     }
 }

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -120,6 +120,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public UniqueUserModuleList getUserModuleList() {
+        return uniqueUserModuleList;
+    }
+
+
+    @Override
     public ObservableList<Module> getFilteredModuleList() {
         return filteredModuleList;
 

--- a/src/main/java/nus/climods/model/UserPrefs.java
+++ b/src/main/java/nus/climods/model/UserPrefs.java
@@ -14,6 +14,8 @@ import nus.climods.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
+    private Path userModuleListFilePath = Paths.get("data", "userModuleList.json");
+
     private Path addressBookFilePath = Paths.get("data", "addressbook.json");
     private String academicYear = "2022-2023";
 
@@ -49,6 +51,14 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
+    public Path getUserModuleListFilePath() {
+        return addressBookFilePath;
+    }
+
+    public void setUserModuleListFilePath(Path userModuleListFilePath) {
+        requireNonNull(userModuleListFilePath);
+        this.addressBookFilePath = userModuleListFilePath;
+    }
     public Path getAddressBookFilePath() {
         return addressBookFilePath;
     }

--- a/src/main/java/nus/climods/model/UserPrefs.java
+++ b/src/main/java/nus/climods/model/UserPrefs.java
@@ -14,7 +14,7 @@ import nus.climods.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path userModuleListFilePath = Paths.get("data", "userModuleList.json");
+    private final Path userModuleListFilePath = Paths.get("data", "userModuleList.json");
 
     private Path addressBookFilePath = Paths.get("data", "addressbook.json");
     private String academicYear = "2022-2023";
@@ -52,7 +52,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     }
 
     public Path getUserModuleListFilePath() {
-        return addressBookFilePath;
+        return userModuleListFilePath;
     }
 
     public void setUserModuleListFilePath(Path userModuleListFilePath) {

--- a/src/main/java/nus/climods/model/UserPrefs.java
+++ b/src/main/java/nus/climods/model/UserPrefs.java
@@ -59,6 +59,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         requireNonNull(userModuleListFilePath);
         this.addressBookFilePath = userModuleListFilePath;
     }
+
     public Path getAddressBookFilePath() {
         return addressBookFilePath;
     }

--- a/src/main/java/nus/climods/model/module/UniqueUserModuleList.java
+++ b/src/main/java/nus/climods/model/module/UniqueUserModuleList.java
@@ -5,6 +5,7 @@ import static nus.climods.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -35,6 +36,7 @@ public class UniqueUserModuleList implements Iterable<UserModule> {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameUserModule);
     }
+
 
     /**
      * Adds a module to the list. The module must not already exist in the list.
@@ -70,10 +72,15 @@ public class UniqueUserModuleList implements Iterable<UserModule> {
     /**
      * Removes the equivalent module from the list. The module must exist in the list.
      */
-    public void remove(UserModule toRemove) {
+    public void remove(String toRemove) {
         requireNonNull(toRemove);
-        if (!internalList.remove(toRemove)) {
+        Optional<UserModule> deleteMod = internalList.stream()
+                .filter(mod -> mod.getUserModuleCode().equals(toRemove.toUpperCase()))
+                .findFirst();
+        if (deleteMod.isEmpty()) {
             throw new UserModuleNotFoundException();
+        } else {
+            internalList.remove(deleteMod.get());
         }
     }
 

--- a/src/main/java/nus/climods/model/module/UserModule.java
+++ b/src/main/java/nus/climods/model/module/UserModule.java
@@ -1,12 +1,6 @@
 package nus.climods.model.module;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-
-import nus.climods.logic.commands.exceptions.CommandException;
-import nus.climods.logic.parser.exceptions.ParseException;
-import nus.climods.model.Model;
 
 /**
  * Class representing module a User has in their My Modules list
@@ -15,46 +9,35 @@ public class UserModule {
     public static final String MESSAGE_MODULE_NOT_FOUND = "Module not in current NUS curriculum";
 
     // Identity fields
-    private final Module listModule;
 
     //TODO: Remove when implement tutorial/lecture/selectedSemester support
     private String tutorial = "Tutorial: Monday, 1400-1500";
     private String lecture = "Lecture: Friday, 1600-1800";
     private String selectedSemester;
+    private String moduleCode;
 
     /**
      * Creates a UserModule
-     * @param moduleCode String for the module code
-     * @throws ParseException if module code is not a valid module in current NUS curriculum
+     * @param module chosen by user
      */
-    public UserModule(String moduleCode, Model model) throws CommandException {
-        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
-
-        if (optionalModule.isEmpty()) {
-            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
-        }
-
-        listModule = optionalModule.get();
+    public UserModule(Module module) {
+        this.moduleCode = module.getCode();
+        // Todo:
+        this.selectedSemester = module.getSemesters().contains(1) ? "Semester 1" : "Semester 2";
     }
 
     /**
      * Creates a UserModule from json {@code JsonAdaptedUserModule} object
      * @param moduleCode String for the module code
-     * @throws ParseException if module code is not a valid module in current NUS curriculum
      * @param lecture cached selected lectures slot
      * @param tutorial cached selected tutorial slot
-     * @throws CommandException
+     * @param selectedSemesters the semesters selected
      */
-    public UserModule(String moduleCode, Model model, String lecture, String tutorial, String selectedSemesters) throws CommandException {
-        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
-
-        if (optionalModule.isEmpty()) {
-            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
-        }
-
-        listModule = optionalModule.get();
+    public UserModule(String moduleCode, String lecture, String tutorial, String selectedSemesters) {
+        this.moduleCode = moduleCode;
         this.lecture = lecture;
         this.tutorial = tutorial;
+        // TODO: update with user's selected semester
         this.selectedSemester = selectedSemesters;
     }
 
@@ -62,28 +45,10 @@ public class UserModule {
      * Constructor for use purely in testing stub classes.
      */
     protected UserModule() {
-        this.listModule = null;
-    }
-
-    public Module getApiModule() {
-        return this.listModule;
     }
 
     public String getUserModuleCode() {
-        return this.listModule.getCode();
-    }
-
-    public String getUserModuleTitle() {
-        return this.listModule.getTitle();
-    }
-
-    public String getDepartment() {
-        return listModule.getDepartment();
-    }
-
-    //TODO: fix getWorkload from API
-    public String getWorkload() {
-        return listModule.getModuleCredit();
+        return this.moduleCode;
     }
 
     //TODO: add Tutorial method
@@ -103,13 +68,10 @@ public class UserModule {
         this.lecture = lecture;
     }
 
-    private List<Integer> getAvailableSemesters() {
-        return listModule.getSemesters();
-    }
 
     // TODO: update with user's selected semester
     public String getSelectedSemester() {
-        return getAvailableSemesters().contains(1) ? "Semester 1" : "Semester 2";
+        return selectedSemester;
     }
 
     /**
@@ -145,7 +107,7 @@ public class UserModule {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(listModule);
+        return Objects.hash(moduleCode, selectedSemester, lecture, tutorial);
     }
 
     @Override

--- a/src/main/java/nus/climods/model/module/UserModule.java
+++ b/src/main/java/nus/climods/model/module/UserModule.java
@@ -17,9 +17,10 @@ public class UserModule {
     // Identity fields
     private final Module listModule;
 
-    //TODO: Remove when implement tutorial/lecture support
+    //TODO: Remove when implement tutorial/lecture/selectedSemester support
     private String tutorial = "Tutorial: Monday, 1400-1500";
     private String lecture = "Lecture: Friday, 1600-1800";
+    private String selectedSemester;
 
     /**
      * Creates a UserModule
@@ -34,6 +35,27 @@ public class UserModule {
         }
 
         listModule = optionalModule.get();
+    }
+
+    /**
+     * Creates a UserModule from json {@code JsonAdaptedUserModule} object
+     * @param moduleCode String for the module code
+     * @throws ParseException if module code is not a valid module in current NUS curriculum
+     * @param lecture cached selected lectures slot
+     * @param tutorial cached selected tutorial slot
+     * @throws CommandException
+     */
+    public UserModule(String moduleCode, Model model, String lecture, String tutorial, String selectedSemesters) throws CommandException {
+        Optional<Module> optionalModule = model.getModuleList().getListModule(moduleCode);
+
+        if (optionalModule.isEmpty()) {
+            throw new CommandException(MESSAGE_MODULE_NOT_FOUND);
+        }
+
+        listModule = optionalModule.get();
+        this.lecture = lecture;
+        this.tutorial = tutorial;
+        this.selectedSemester = selectedSemesters;
     }
 
     /**

--- a/src/main/java/nus/climods/storage/Storage.java
+++ b/src/main/java/nus/climods/storage/Storage.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.UserPrefs;
+import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.storage.module.ModuleListStorage;
 import nus.climods.storage.module.user.UserModuleListStorage;
 
@@ -21,4 +22,6 @@ public interface Storage extends UserPrefsStorage, ModuleListStorage {
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
 
     UserModuleListStorage getUserModuleListStorage();
+
+    void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws IOException;
 }

--- a/src/main/java/nus/climods/storage/Storage.java
+++ b/src/main/java/nus/climods/storage/Storage.java
@@ -7,6 +7,7 @@ import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.UserPrefs;
 import nus.climods.storage.module.ModuleListStorage;
+import nus.climods.storage.module.user.UserModuleListStorage;
 
 /**
  * API of the Storage component
@@ -18,4 +19,6 @@ public interface Storage extends UserPrefsStorage, ModuleListStorage {
 
     @Override
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
+
+    UserModuleListStorage getUserModuleListStorage();
 }

--- a/src/main/java/nus/climods/storage/Storage.java
+++ b/src/main/java/nus/climods/storage/Storage.java
@@ -7,6 +7,7 @@ import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.UserPrefs;
 import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.storage.exceptions.StorageException;
 import nus.climods.storage.module.ModuleListStorage;
 import nus.climods.storage.module.user.UserModuleListStorage;
 
@@ -23,5 +24,5 @@ public interface Storage extends UserPrefsStorage, ModuleListStorage {
 
     UserModuleListStorage getUserModuleListStorage();
 
-    void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws IOException;
+    void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws StorageException;
 }

--- a/src/main/java/nus/climods/storage/StorageManager.java
+++ b/src/main/java/nus/climods/storage/StorageManager.java
@@ -12,6 +12,7 @@ import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.UserPrefs;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
+import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.storage.module.ModuleListStorage;
 import nus.climods.storage.module.user.UserModuleListStorage;
 
@@ -82,5 +83,10 @@ public class StorageManager implements Storage {
     @Override
     public void saveModuleList(List<Module> modules, Path filePath) throws IOException {
 
+    }
+
+    @Override
+    public void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws IOException {
+        userModuleListStorage.saveUserModuleList(uniqueUserModuleList);
     }
 }

--- a/src/main/java/nus/climods/storage/StorageManager.java
+++ b/src/main/java/nus/climods/storage/StorageManager.java
@@ -13,6 +13,7 @@ import nus.climods.model.UserPrefs;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.storage.exceptions.StorageException;
 import nus.climods.storage.module.ModuleListStorage;
 import nus.climods.storage.module.user.UserModuleListStorage;
 
@@ -86,7 +87,7 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws IOException {
+    public void saveUserModuleList(UniqueUserModuleList uniqueUserModuleList) throws StorageException {
         userModuleListStorage.saveUserModuleList(uniqueUserModuleList);
     }
 }

--- a/src/main/java/nus/climods/storage/StorageManager.java
+++ b/src/main/java/nus/climods/storage/StorageManager.java
@@ -37,6 +37,10 @@ public class StorageManager implements Storage {
         this.userModuleListStorage = userModuleListStorage;
     }
 
+    public UserModuleListStorage getUserModuleListStorage() {
+        return userModuleListStorage;
+    }
+
     // ================ UserPrefs methods ==============================
 
     @Override

--- a/src/main/java/nus/climods/storage/exceptions/StorageException.java
+++ b/src/main/java/nus/climods/storage/exceptions/StorageException.java
@@ -1,0 +1,18 @@
+package nus.climods.storage.exceptions;
+
+/**
+ * Represents an error which occurs during execution of a {@link nus.climods.storage.Storage}.
+ */
+public class StorageException extends Exception {
+
+    public StorageException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@code StorageException} with the specified detail {@code message} and {@code cause}.
+     */
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
@@ -1,111 +1,124 @@
 package nus.climods.storage.module.user;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import nus.climods.commons.exceptions.IllegalValueException;
-import nus.climods.model.person.Address;
-import nus.climods.model.person.Email;
-import nus.climods.model.person.Name;
-import nus.climods.model.person.Person;
-import nus.climods.model.person.Phone;
-import nus.climods.model.tag.Tag;
-import nus.climods.storage.JsonAdaptedTag;
+import io.swagger.annotations.ApiModelProperty;
+import nus.climods.logic.commands.exceptions.CommandException;
+import nus.climods.model.Model;
+import nus.climods.model.module.UserModule;
 
 /**
- * Jackson-friendly version of {@link Module}.
+ * Jackson-friendly version of {@link UserModule}.
  */
+@JsonPropertyOrder({
+    JsonAdaptedUserModule.JSON_PROPERTY_MODULE_CODE,
+    JsonAdaptedUserModule.JSON_PROPERTY_TUTORIAL,
+    JsonAdaptedUserModule.JSON_PROPERTY_LECTURE,
+    JsonAdaptedUserModule.JSON_PROPERTY_SELECTED_SEMESTERS
+})
+
 class JsonAdaptedUserModule {
-
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Module's %s field is missing!";
-
-    // TODO: Replace with the variables of module.
-    private final String name;
-    private final String phone;
-    private final String email;
-    private final String address;
-    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    public static final String JSON_PROPERTY_MODULE_CODE = "moduleCode";
+    public static final String JSON_PROPERTY_TUTORIAL = "tutorial";
+    public static final String JSON_PROPERTY_LECTURE = "lecture";
+    public static final String JSON_PROPERTY_SELECTED_SEMESTERS = "selectedSemesters";
+    private final UserModule source;
+    private final String moduleCode;
+    private final String tutorial;
+    private final String lecture;
+    private final String selectedSemesters;
 
     /**
-     * Constructs a {@code JsonAdaptedModule} with the given module's details.
+     * Converts a given {@code UserModule} into this class for Jackson use.
      */
-    @JsonCreator
-    public JsonAdaptedUserModule(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-        @JsonProperty("email") String email, @JsonProperty("address") String address,
-        @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        if (tagged != null) {
-            this.tagged.addAll(tagged);
-        }
+    public JsonAdaptedUserModule(UserModule source) {
+        this.source = source;
+        this.moduleCode = source.getUserModuleCode();
+        this.selectedSemesters = source.getSelectedSemester();
+        this.tutorial = source.getTutorial();
+        this.lecture = source.getLecture();
     }
 
     /**
-     * Converts a given {@code Module} into this class for Jackson use.
+     * Converts this Jackson-friendly adapted module object into the model's {@code UserModule} object.
+     * @param model Current list of modules
      */
-    public JsonAdaptedUserModule(Person source) {
-        name = source.getName().fullName;
-        phone = source.getPhone().value;
-        email = source.getEmail().value;
-        address = source.getAddress().value;
-        tagged.addAll(source.getTags().stream()
-            .map(JsonAdaptedTag::new)
-            .collect(Collectors.toList()));
+    public UserModule toModelType(Model model) throws CommandException {
+        return new UserModule(moduleCode, model, lecture, tutorial, selectedSemesters);
     }
 
     /**
-     * Converts this Jackson-friendly adapted module object into the model's {@code Module} object.
+     * Get moduleCode
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted module.
-     */
-    public Person toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tagged) {
-            personTags.add(tag.toModelType());
-        }
+     * @return moduleCode
+     **/
+    @javax.annotation.Nonnull
+    @ApiModelProperty(example = "EL1101E", required = true, value = "")
+    @JsonProperty(JSON_PROPERTY_MODULE_CODE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
-        if (name == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
-        }
-        if (!Name.isValidName(name)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
-        }
-        final Name modelName = new Name(name);
-
-        if (phone == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
-        }
-        if (!Phone.isValidPhone(phone)) {
-            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
-        }
-        final Phone modelPhone = new Phone(phone);
-
-        if (email == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
-        }
-        if (!Email.isValidEmail(email)) {
-            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
-        }
-        final Email modelEmail = new Email(email);
-
-        if (address == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
-        }
-        if (!Address.isValidAddress(address)) {
-            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
-        }
-        final Address modelAddress = new Address(address);
-
-        final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+    public String getModuleCode() {
+        return moduleCode;
     }
 
+    /**
+     * Get selectedSemesters
+     *
+     * @return selectedSemesters
+     **/
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_SELECTED_SEMESTERS)
+
+    public String getSelectedSemesters() {
+        return selectedSemesters;
+    }
+    /**
+     * Get lecture slot
+     *
+     * @return lecture
+     **/
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_LECTURE)
+
+    public String getLecture() {
+        return lecture;
+    }
+    /**
+     * Get tutorial slot
+     *
+     * @return tutorial
+     **/
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_TUTORIAL)
+
+    public String getTutorial() {
+        return tutorial;
+    }
+    /**
+     * Return true if this JsonAdaptedUserModule object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JsonAdaptedUserModule userModule = (JsonAdaptedUserModule) o;
+        return Objects.equals(this.moduleCode, userModule.moduleCode)
+                && Objects.equals(this.lecture, userModule.lecture)
+                && Objects.equals(this.selectedSemesters, userModule.selectedSemesters)
+                && Objects.equals(this.lecture, userModule.lecture)
+                && Objects.equals(this.tutorial, userModule.tutorial);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode, selectedSemesters, lecture, tutorial);
+    }
 }

--- a/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.swagger.annotations.ApiModelProperty;
 import nus.climods.logic.commands.exceptions.CommandException;
-import nus.climods.model.Model;
 import nus.climods.model.module.UserModule;
 
 /**
@@ -45,10 +44,9 @@ class JsonAdaptedUserModule {
 
     /**
      * Converts this Jackson-friendly adapted module object into the model's {@code UserModule} object.
-     * @param model Current list of modules
      */
-    public UserModule toModelType(Model model) throws CommandException {
-        return new UserModule(moduleCode, model, lecture, tutorial, selectedSemesters);
+    public UserModule toModelType() throws CommandException {
+        return new UserModule(moduleCode, lecture, tutorial, selectedSemesters);
     }
 
     /**
@@ -57,7 +55,6 @@ class JsonAdaptedUserModule {
      * @return moduleCode
      **/
     @javax.annotation.Nonnull
-    @ApiModelProperty(example = "EL1101E", required = true, value = "")
     @JsonProperty(JSON_PROPERTY_MODULE_CODE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -113,7 +110,6 @@ class JsonAdaptedUserModule {
         return Objects.equals(this.moduleCode, userModule.moduleCode)
                 && Objects.equals(this.lecture, userModule.lecture)
                 && Objects.equals(this.selectedSemesters, userModule.selectedSemesters)
-                && Objects.equals(this.lecture, userModule.lecture)
                 && Objects.equals(this.tutorial, userModule.tutorial);
     }
 

--- a/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonAdaptedUserModule.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import io.swagger.annotations.ApiModelProperty;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.module.UserModule;
 
@@ -25,21 +24,23 @@ class JsonAdaptedUserModule {
     public static final String JSON_PROPERTY_TUTORIAL = "tutorial";
     public static final String JSON_PROPERTY_LECTURE = "lecture";
     public static final String JSON_PROPERTY_SELECTED_SEMESTERS = "selectedSemesters";
-    private final UserModule source;
-    private final String moduleCode;
-    private final String tutorial;
-    private final String lecture;
-    private final String selectedSemesters;
+    private String moduleCode;
+    private String tutorial;
+    private String lecture;
+    private String selectedSemesters;
 
     /**
      * Converts a given {@code UserModule} into this class for Jackson use.
      */
     public JsonAdaptedUserModule(UserModule source) {
-        this.source = source;
         this.moduleCode = source.getUserModuleCode();
         this.selectedSemesters = source.getSelectedSemester();
         this.tutorial = source.getTutorial();
         this.lecture = source.getLecture();
+    }
+
+    public JsonAdaptedUserModule() {
+
     }
 
     /**
@@ -61,6 +62,11 @@ class JsonAdaptedUserModule {
     public String getModuleCode() {
         return moduleCode;
     }
+    @JsonProperty(JSON_PROPERTY_MODULE_CODE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public void setModuleCode(String moduleCode) {
+        this.moduleCode = moduleCode;
+    }
 
     /**
      * Get selectedSemesters
@@ -73,6 +79,14 @@ class JsonAdaptedUserModule {
     public String getSelectedSemesters() {
         return selectedSemesters;
     }
+
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_SELECTED_SEMESTERS)
+
+    public void setSelectedSemesters(String selectedSemesters) {
+        this.selectedSemesters = selectedSemesters;
+    }
+
     /**
      * Get lecture slot
      *
@@ -84,6 +98,13 @@ class JsonAdaptedUserModule {
     public String getLecture() {
         return lecture;
     }
+
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_LECTURE)
+    public void setLecture(String lecture) {
+        this.lecture = lecture;
+    }
+
     /**
      * Get tutorial slot
      *
@@ -94,6 +115,13 @@ class JsonAdaptedUserModule {
 
     public String getTutorial() {
         return tutorial;
+    }
+
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_TUTORIAL)
+
+    public void setTutorial(String tutorial) {
+        this.tutorial = tutorial;
     }
     /**
      * Return true if this JsonAdaptedUserModule object is equal to o.

--- a/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
@@ -1,7 +1,6 @@
 package nus.climods.storage.module.user;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -9,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nus.climods.commons.exceptions.IllegalValueException;
 import nus.climods.logic.commands.exceptions.CommandException;
-import nus.climods.model.Model;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
 
@@ -21,16 +19,12 @@ class JsonSerializableUserModuleList {
     public static final String MESSAGE_DUPLICATE_MODULE = "Modules list contains duplicate module(s).";
 
     private final List<JsonAdaptedUserModule> modules;
-    private final Model model;
     /**
      * Constructs a {@code JsonSerializableUserModuleList} with the given modules and model
      */
     @JsonCreator
-    public JsonSerializableUserModuleList(@JsonProperty("userModules") UniqueUserModuleList modules,
-                                          Model model) {
-        this.modules = modules.asUnmodifiableObservableList().stream().map(userModule ->
-                new JsonAdaptedUserModule(userModule)).collect(Collectors.toList());
-        this.model = model;
+    public JsonSerializableUserModuleList(@JsonProperty("userModules") List<JsonAdaptedUserModule> modules) {
+        this.modules = modules;
     }
     /**
      * Converts this user module list into the model's {@code UniqueUserModuleList} object.
@@ -40,7 +34,7 @@ class JsonSerializableUserModuleList {
     public UniqueUserModuleList toModelType() throws IllegalValueException, CommandException {
         UniqueUserModuleList userModuleList = new UniqueUserModuleList();
         for (JsonAdaptedUserModule jsonAdaptedModule : modules) {
-            UserModule module = jsonAdaptedModule.toModelType(model);
+            UserModule module = jsonAdaptedModule.toModelType();
             if (userModuleList.contains(module)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE);
             }

--- a/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
@@ -33,7 +33,7 @@ class JsonSerializableUserModuleList {
         this.model = model;
     }
     /**
-     * Converts this address book into the model's {@code AddressBook} object.
+     * Converts this user module list into the model's {@code UniqueUserModuleList} object.
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */

--- a/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonSerializableUserModuleList.java
@@ -10,6 +10,7 @@ import nus.climods.commons.exceptions.IllegalValueException;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * An Immutable userModuleList that is serializable to JSON format.
@@ -31,12 +32,12 @@ class JsonSerializableUserModuleList {
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
-    public UniqueUserModuleList toModelType() throws IllegalValueException, CommandException {
+    public UniqueUserModuleList toModelType() throws CommandException, StorageException {
         UniqueUserModuleList userModuleList = new UniqueUserModuleList();
         for (JsonAdaptedUserModule jsonAdaptedModule : modules) {
             UserModule module = jsonAdaptedModule.toModelType();
             if (userModuleList.contains(module)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE);
+                throw new StorageException(MESSAGE_DUPLICATE_MODULE);
             }
             userModuleList.add(module);
         }

--- a/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
@@ -4,8 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import nus.climods.commons.core.LogsCenter;
 import nus.climods.commons.exceptions.DataConversionException;
@@ -13,7 +15,6 @@ import nus.climods.commons.exceptions.IllegalValueException;
 import nus.climods.commons.util.FileUtil;
 import nus.climods.commons.util.JsonUtil;
 import nus.climods.logic.commands.exceptions.CommandException;
-import nus.climods.model.Model;
 import nus.climods.model.module.UniqueUserModuleList;
 
 /**
@@ -25,16 +26,12 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
 
     private final Path filePath;
 
-    private final Model model;
-
     /**
      * Creates JsonUserModuleListStorage with
      * @param filePath of the stored json
-     * @param model of all modules
      */
-    public JsonUserModuleListStorage(Path filePath, Model model) {
+    public JsonUserModuleListStorage(Path filePath) {
         this.filePath = filePath;
-        this.model = model;
     }
 
     public Path getUserModuleListFilePath() {
@@ -84,7 +81,11 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
         requireNonNull(filePath);
 
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableUserModuleList(userModuleList, model), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableUserModuleList(convertToList(userModuleList)), filePath);
     }
 
+    private List<JsonAdaptedUserModule> convertToList(UniqueUserModuleList modules) {
+        return modules.asUnmodifiableObservableList().stream().map(JsonAdaptedUserModule::new)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
@@ -11,11 +11,11 @@ import java.util.stream.Collectors;
 
 import nus.climods.commons.core.LogsCenter;
 import nus.climods.commons.exceptions.DataConversionException;
-import nus.climods.commons.exceptions.IllegalValueException;
 import nus.climods.commons.util.FileUtil;
 import nus.climods.commons.util.JsonUtil;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.storage.exceptions.StorageException;
 
 /**
  * A class to access UserModuleList data stored as a json file on the hard disk.
@@ -60,15 +60,19 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
 
         try {
             return Optional.of(jsonUserModuleList.get().toModelType());
-        } catch (IllegalValueException | CommandException ive) {
+        } catch (StorageException | CommandException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
     }
 
     @Override
-    public void saveUserModuleList(UniqueUserModuleList userModuleList) throws IOException {
-        saveUserModuleList(userModuleList, filePath);
+    public void saveUserModuleList(UniqueUserModuleList userModuleList) throws StorageException {
+        try {
+            saveUserModuleList(userModuleList, filePath);
+        } catch (IOException e) {
+            throw new StorageException(e.getMessage(), e);
+        }
     }
 
     /**

--- a/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
+++ b/src/main/java/nus/climods/storage/module/user/JsonUserModuleListStorage.java
@@ -12,7 +12,9 @@ import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.commons.exceptions.IllegalValueException;
 import nus.climods.commons.util.FileUtil;
 import nus.climods.commons.util.JsonUtil;
-import nus.climods.model.ReadOnlyAddressBook;
+import nus.climods.logic.commands.exceptions.CommandException;
+import nus.climods.model.Model;
+import nus.climods.model.module.UniqueUserModuleList;
 
 /**
  * A class to access UserModuleList data stored as a json file on the hard disk.
@@ -23,8 +25,16 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
 
     private final Path filePath;
 
-    public JsonUserModuleListStorage(Path filePath) {
+    private final Model model;
+
+    /**
+     * Creates JsonUserModuleListStorage with
+     * @param filePath of the stored json
+     * @param model of all modules
+     */
+    public JsonUserModuleListStorage(Path filePath, Model model) {
         this.filePath = filePath;
+        this.model = model;
     }
 
     public Path getUserModuleListFilePath() {
@@ -32,7 +42,7 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
     }
 
     @Override
-    public Optional<ReadOnlyAddressBook> readUserModuleList() throws DataConversionException {
+    public Optional<UniqueUserModuleList> readUserModuleList() throws DataConversionException {
         return readUserModuleList(filePath);
     }
 
@@ -42,7 +52,7 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
      * @param filePath location of the data. Cannot be null.
      * @throws DataConversionException if the file is not in the correct format.
      */
-    public Optional<ReadOnlyAddressBook> readUserModuleList(Path filePath) throws DataConversionException {
+    public Optional<UniqueUserModuleList> readUserModuleList(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
         Optional<JsonSerializableUserModuleList> jsonUserModuleList = JsonUtil.readJsonFile(
@@ -53,28 +63,28 @@ public class JsonUserModuleListStorage implements UserModuleListStorage {
 
         try {
             return Optional.of(jsonUserModuleList.get().toModelType());
-        } catch (IllegalValueException ive) {
+        } catch (IllegalValueException | CommandException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
     }
 
     @Override
-    public void saveUserModuleList(ReadOnlyAddressBook userModuleList) throws IOException {
+    public void saveUserModuleList(UniqueUserModuleList userModuleList) throws IOException {
         saveUserModuleList(userModuleList, filePath);
     }
 
     /**
-     * Similar to {@link #saveUserModuleList(ReadOnlyAddressBook)}.
+     * Similar to {@link #saveUserModuleList(UniqueUserModuleList)}.
      *
      * @param filePath location of the data. Cannot be null.
      */
-    public void saveUserModuleList(ReadOnlyAddressBook userModuleList, Path filePath) throws IOException {
+    public void saveUserModuleList(UniqueUserModuleList userModuleList, Path filePath) throws IOException {
         requireNonNull(userModuleList);
         requireNonNull(filePath);
 
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableUserModuleList(userModuleList), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableUserModuleList(userModuleList, model), filePath);
     }
 
 }

--- a/src/main/java/nus/climods/storage/module/user/UserModuleListStorage.java
+++ b/src/main/java/nus/climods/storage/module/user/UserModuleListStorage.java
@@ -5,12 +5,12 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import nus.climods.commons.exceptions.DataConversionException;
-import nus.climods.model.ReadOnlyAddressBook;
+import nus.climods.model.module.UniqueUserModuleList;
 
 // TODO: Rename all "ReadOnlyAddressBook" to "ReadOnlyUserModuleList"
 
 /**
- * Represents a storage for {@link nus.climods.model.AddressBook}.
+ * Represents a storage for {@link nus.climods.model.module.UniqueUserModuleList}
  */
 public interface UserModuleListStorage {
 
@@ -20,30 +20,30 @@ public interface UserModuleListStorage {
     Path getUserModuleListFilePath();
 
     /**
-     * Returns user module list data as a {@link ReadOnlyAddressBook}. Returns {@code Optional.empty()} if storage file
-     * is not found.
+     * Returns user module list data as a {@link nus.climods.model.module.UniqueUserModuleList}.
+     * Returns {@code Optional.empty()} if storage file is not found.
      *
      * @throws DataConversionException if the data in storage is not in the expected format.
      * @throws IOException             if there was any problem when reading from the storage.
      */
-    Optional<ReadOnlyAddressBook> readUserModuleList() throws DataConversionException, IOException;
+    Optional<UniqueUserModuleList> readUserModuleList() throws DataConversionException, IOException;
 
     /**
      * @see #getUserModuleListFilePath()
      */
-    Optional<ReadOnlyAddressBook> readUserModuleList(Path filePath) throws DataConversionException, IOException;
+    Optional<UniqueUserModuleList> readUserModuleList(Path filePath) throws DataConversionException, IOException;
 
     /**
-     * Saves the given {@link ReadOnlyAddressBook} to the storage.
+     * Saves the given {@link UniqueUserModuleList} to the storage.
      *
      * @param userModuleList cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void saveUserModuleList(ReadOnlyAddressBook userModuleList) throws IOException;
+    void saveUserModuleList(UniqueUserModuleList userModuleList) throws IOException;
 
     /**
-     * @see #saveUserModuleList(ReadOnlyAddressBook)
+     * @see #saveUserModuleList(UniqueUserModuleList)
      */
-    void saveUserModuleList(ReadOnlyAddressBook userModuleList, Path filePath) throws IOException;
+    void saveUserModuleList(UniqueUserModuleList userModuleList, Path filePath) throws IOException;
 
 }

--- a/src/main/java/nus/climods/storage/module/user/UserModuleListStorage.java
+++ b/src/main/java/nus/climods/storage/module/user/UserModuleListStorage.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.storage.exceptions.StorageException;
 
 // TODO: Rename all "ReadOnlyAddressBook" to "ReadOnlyUserModuleList"
 
@@ -26,12 +27,12 @@ public interface UserModuleListStorage {
      * @throws DataConversionException if the data in storage is not in the expected format.
      * @throws IOException             if there was any problem when reading from the storage.
      */
-    Optional<UniqueUserModuleList> readUserModuleList() throws DataConversionException, IOException;
+    Optional<UniqueUserModuleList> readUserModuleList() throws DataConversionException;
 
     /**
      * @see #getUserModuleListFilePath()
      */
-    Optional<UniqueUserModuleList> readUserModuleList(Path filePath) throws DataConversionException, IOException;
+    Optional<UniqueUserModuleList> readUserModuleList(Path filePath) throws DataConversionException;
 
     /**
      * Saves the given {@link UniqueUserModuleList} to the storage.
@@ -39,7 +40,7 @@ public interface UserModuleListStorage {
      * @param userModuleList cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void saveUserModuleList(UniqueUserModuleList userModuleList) throws IOException;
+    void saveUserModuleList(UniqueUserModuleList userModuleList) throws StorageException;
 
     /**
      * @see #saveUserModuleList(UniqueUserModuleList)

--- a/src/main/java/nus/climods/ui/MainWindow.java
+++ b/src/main/java/nus/climods/ui/MainWindow.java
@@ -1,5 +1,6 @@
 package nus.climods.ui;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
@@ -215,6 +216,8 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/nus/climods/ui/MainWindow.java
+++ b/src/main/java/nus/climods/ui/MainWindow.java
@@ -1,6 +1,5 @@
 package nus.climods.ui;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
@@ -21,6 +20,7 @@ import nus.climods.logic.Logic;
 import nus.climods.logic.commands.CommandResult;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
+import nus.climods.storage.exceptions.StorageException;
 import nus.climods.ui.common.CommandBox;
 import nus.climods.ui.common.HelpWindow;
 import nus.climods.ui.common.ResultDisplay;
@@ -197,7 +197,7 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @see Logic#execute(String)
      */
-    private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
+    private CommandResult executeCommand(String commandText) throws CommandException, ParseException, StorageException {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
@@ -212,12 +212,10 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
-        } catch (CommandException | ParseException e) {
+        } catch (CommandException | ParseException | StorageException e) {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/nus/climods/ui/common/CommandBox.java
+++ b/src/main/java/nus/climods/ui/common/CommandBox.java
@@ -8,6 +8,7 @@ import nus.climods.logic.Logic;
 import nus.climods.logic.commands.CommandResult;
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.logic.parser.exceptions.ParseException;
+import nus.climods.storage.exceptions.StorageException;
 import nus.climods.ui.UiPart;
 
 /**
@@ -46,7 +47,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-        } catch (CommandException | ParseException e) {
+        } catch (CommandException | ParseException | StorageException e) {
             setStyleToIndicateCommandFailure();
         }
     }
@@ -82,7 +83,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see Logic#execute(String)
          */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
+        CommandResult execute(String commandText) throws CommandException, ParseException, StorageException;
     }
 
 }

--- a/src/test/data/JsonUserModuleListStorageTest/notJsonFormatModuleSummaryList.json
+++ b/src/test/data/JsonUserModuleListStorageTest/notJsonFormatModuleSummaryList.json
@@ -1,0 +1,1 @@
+not json format!

--- a/src/test/data/JsonUserModuleListStorageTest/validJsonFormatModuleSummaryList.json
+++ b/src/test/data/JsonUserModuleListStorageTest/validJsonFormatModuleSummaryList.json
@@ -1,0 +1,22 @@
+{
+  "modules": [
+    {
+      "moduleCode": "AC5001",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    },
+    {
+      "moduleCode": "CS2103",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    },
+    {
+      "moduleCode": "CS2030S",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    }
+  ]
+}

--- a/src/test/data/JsonUserModuleListStorageTest/validJsonFormatModuleSummaryList.json
+++ b/src/test/data/JsonUserModuleListStorageTest/validJsonFormatModuleSummaryList.json
@@ -2,21 +2,24 @@
   "modules": [
     {
       "moduleCode": "AC5001",
-      "tutorial": "Test data",
-      "lecture": "Test data",
-      "selectedSemesters": "Semester 1"
+      "title": "Architectural History of Singapore",
+      "semesters": [
+        1
+      ]
     },
     {
-      "moduleCode": "CS2103",
-      "tutorial": "Test data",
-      "lecture": "Test data",
-      "selectedSemesters": "Semester 1"
+      "moduleCode": "AC5002",
+      "title": "Conservation Approaches and Philosophies",
+      "semesters": [
+        1
+      ]
     },
     {
-      "moduleCode": "CS2030S",
-      "tutorial": "Test data",
-      "lecture": "Test data",
-      "selectedSemesters": "Semester 1"
+      "moduleCode": "AC5003",
+      "title": "Urban Conservation and Regeneration",
+      "semesters": [
+        2
+      ]
     }
   ]
 }

--- a/src/test/data/JsonUserModuleListStorageTest/validJsonFormatUserModuleList.json
+++ b/src/test/data/JsonUserModuleListStorageTest/validJsonFormatUserModuleList.json
@@ -1,0 +1,22 @@
+{
+  "modules": [
+    {
+      "moduleCode": "AC5001",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    },
+    {
+      "moduleCode": "CS2103",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    },
+    {
+      "moduleCode": "CS2030S",
+      "tutorial": "Test data",
+      "lecture": "Test data",
+      "selectedSemesters": "Semester 1"
+    }
+  ]
+}

--- a/src/test/java/nus/climods/logic/commands/ExitCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/ExitCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.ModelManager;
 import nus.climods.model.UserPrefs;
@@ -17,11 +18,11 @@ public class ExitCommandTest {
             new UserPrefs());
 
     @Test
-    public void execute_exit_success() {
+    public void execute_exit_success() throws CommandException {
         String expectedMessage = MESSAGE_EXIT_ACKNOWLEDGEMENT;
 
         ExitCommand exitCommand = new ExitCommand();
-        CommandResult commandResult = exitCommand.execute(model, null);
+        CommandResult commandResult = exitCommand.execute(model);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
     }

--- a/src/test/java/nus/climods/logic/commands/ExitCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/ExitCommandTest.java
@@ -21,7 +21,7 @@ public class ExitCommandTest {
         String expectedMessage = MESSAGE_EXIT_ACKNOWLEDGEMENT;
 
         ExitCommand exitCommand = new ExitCommand();
-        CommandResult commandResult = exitCommand.execute(model);
+        CommandResult commandResult = exitCommand.execute(model, null);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
     }

--- a/src/test/java/nus/climods/logic/commands/FindCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/FindCommandTest.java
@@ -17,7 +17,6 @@ import nus.climods.model.UserPrefs;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
-import nus.climods.storage.exceptions.StorageException;
 
 class FindCommandTest {
 
@@ -26,22 +25,22 @@ class FindCommandTest {
             new UserPrefs());
 
     @Test
-    public void execute_zeroKeywords_noModulesFound() throws StorageException {
+    public void execute_zeroKeywords_noModulesFound() {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 0);
 
         FindCommand command = new FindCommand(Collections.emptyList());
-        CommandResult commandResult = command.execute(model, null);
+        CommandResult commandResult = command.execute(model);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(Collections.emptyList(), model.getFilteredModuleList());
     }
 
     @Test
-    public void execute_multipleKeywords_multipleModulesFound() throws StorageException {
+    public void execute_multipleKeywords_multipleModulesFound() {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 3);
 
         FindCommand command = new FindCommand(prepareSearchRegexes("CS2103"));
-        CommandResult commandResult = command.execute(model, null);
+        CommandResult commandResult = command.execute(model);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(model.getFilteredModuleList().stream().map(Module::getCode).collect(Collectors.toList()),
@@ -49,11 +48,11 @@ class FindCommandTest {
     }
 
     @Test
-    public void execute_regexKeywords_multipleModulesFound() throws StorageException {
+    public void execute_regexKeywords_multipleModulesFound() {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 4);
 
         FindCommand command = new FindCommand(prepareSearchRegexes("^CS210[0-3]$"));
-        CommandResult commandResult = command.execute(model, null);
+        CommandResult commandResult = command.execute(model);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(model.getFilteredModuleList().stream().map(Module::getCode).collect(Collectors.toList()),

--- a/src/test/java/nus/climods/logic/commands/FindCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/FindCommandTest.java
@@ -17,7 +17,7 @@ import nus.climods.model.UserPrefs;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
-
+import nus.climods.storage.exceptions.StorageException;
 
 class FindCommandTest {
 
@@ -26,22 +26,22 @@ class FindCommandTest {
             new UserPrefs());
 
     @Test
-    public void execute_zeroKeywords_noModulesFound() {
+    public void execute_zeroKeywords_noModulesFound() throws StorageException {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 0);
 
         FindCommand command = new FindCommand(Collections.emptyList());
-        CommandResult commandResult = command.execute(model);
+        CommandResult commandResult = command.execute(model, null);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(Collections.emptyList(), model.getFilteredModuleList());
     }
 
     @Test
-    public void execute_multipleKeywords_multipleModulesFound() {
+    public void execute_multipleKeywords_multipleModulesFound() throws StorageException {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 3);
 
         FindCommand command = new FindCommand(prepareSearchRegexes("CS2103"));
-        CommandResult commandResult = command.execute(model);
+        CommandResult commandResult = command.execute(model, null);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(model.getFilteredModuleList().stream().map(Module::getCode).collect(Collectors.toList()),
@@ -49,11 +49,11 @@ class FindCommandTest {
     }
 
     @Test
-    public void execute_regexKeywords_multipleModulesFound() {
+    public void execute_regexKeywords_multipleModulesFound() throws StorageException {
         String expectedMessage = String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW, 4);
 
         FindCommand command = new FindCommand(prepareSearchRegexes("^CS210[0-3]$"));
-        CommandResult commandResult = command.execute(model);
+        CommandResult commandResult = command.execute(model, null);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
         assertEquals(model.getFilteredModuleList().stream().map(Module::getCode).collect(Collectors.toList()),

--- a/src/test/java/nus/climods/logic/commands/HelpCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/HelpCommandTest.java
@@ -22,7 +22,7 @@ public class HelpCommandTest {
         String expectedMessage = Messages.MESSAGE_SHOW_HELP;
 
         HelpCommand helpCommand = new HelpCommand();
-        CommandResult commandResult = helpCommand.execute(model, null);
+        CommandResult commandResult = helpCommand.execute(model);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
     }

--- a/src/test/java/nus/climods/logic/commands/HelpCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/HelpCommandTest.java
@@ -22,7 +22,7 @@ public class HelpCommandTest {
         String expectedMessage = Messages.MESSAGE_SHOW_HELP;
 
         HelpCommand helpCommand = new HelpCommand();
-        CommandResult commandResult = helpCommand.execute(model);
+        CommandResult commandResult = helpCommand.execute(model, null);
 
         assertEquals(commandResult.getFeedbackToUser(), expectedMessage);
     }

--- a/src/test/java/nus/climods/logic/commands/ModelStub.java
+++ b/src/test/java/nus/climods/logic/commands/ModelStub.java
@@ -54,14 +54,8 @@ class ModelStub implements Model {
     public boolean hasUserModule(UserModule module) {
         return hasModule;
     }
-
     @Override
-    public boolean filteredListhasUserModule(UserModule module) {
-        return hasModule;
-    }
-
-    @Override
-    public void deleteUserModule(UserModule target) {
+    public void deleteUserModule(String target) {
     }
 
     @Override

--- a/src/test/java/nus/climods/logic/commands/ModelStub.java
+++ b/src/test/java/nus/climods/logic/commands/ModelStub.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import nus.climods.commons.core.GuiSettings;
+import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.module.Module;
@@ -96,5 +97,10 @@ class ModelStub implements Model {
     @Override
     public void setFilteredModuleList(Predicate<Module> predicate) {
 
+    }
+
+    @Override
+    public Module getModule(String moduleCode) throws CommandException {
+        return null;
     }
 }

--- a/src/test/java/nus/climods/logic/commands/ModelStub.java
+++ b/src/test/java/nus/climods/logic/commands/ModelStub.java
@@ -9,6 +9,7 @@ import nus.climods.model.Model;
 import nus.climods.model.ReadOnlyUserPrefs;
 import nus.climods.model.module.Module;
 import nus.climods.model.module.ReadOnlyModuleList;
+import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
 
 
@@ -80,6 +81,11 @@ class ModelStub implements Model {
     @Override
     public void updateFilteredModuleList(Optional<String> facultyCode, Optional<Boolean> hasUser) {
 
+    }
+
+    @Override
+    public UniqueUserModuleList getUserModuleList() {
+        return null;
     }
 
     @Override

--- a/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
+++ b/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
@@ -1,0 +1,87 @@
+package nus.climods.storage.module;
+
+import nus.climods.commons.exceptions.DataConversionException;
+import nus.climods.model.module.ReadOnlyModuleSummaryList;
+import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.storage.module.summary.JsonModuleSummaryListStorage;
+import nus.climods.storage.module.user.JsonUserModuleListStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.client.api.ModulesApi;
+import org.openapitools.client.model.ModuleCondensed;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import static nus.climods.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUserModuleListStorageTest {
+
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonUserModuleListStorageTest");
+
+    @TempDir
+    public Path testFolder;
+
+    @Test
+    public void readModuleSummary_nullFilePath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> readUserModuleList(null));
+    }
+
+    private Optional<UniqueUserModuleList> readUserModuleList(String filePath) throws Exception {
+        return new JsonUserModuleListStorage(Paths.get(filePath))
+            .readUserModuleList(addToTestDataPathIfNotNull(filePath));
+    }
+
+    private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
+        return prefsFileInTestDataFolder != null
+            ? TEST_DATA_FOLDER.resolve(prefsFileInTestDataFolder)
+            : null;
+    }
+
+    @Test
+    public void read_missingFile_emptyResult() throws Exception {
+        assertFalse(readUserModuleList("NonExistentFile.json").isPresent());
+    }
+
+//    @Test
+//    public void read_notJsonFormat_exceptionThrown() {
+//        assertThrows(DataConversionException.class, () -> readUserModuleList(
+//            "notJsonFormatModuleSummaryList.json"));
+//    }
+
+//    @Test
+//    public void readInvalidJsonFormat_fail() throws Exception {
+//        assertTrue(readUserModuleList("validJsonFormatModuleSummaryList.json").isEmpty());
+//    }
+
+    @Test
+    public void readValidJsonFormat_success() throws Exception {
+        assertTrue(readUserModuleList("validJsonFormatUserModuleList.json").isPresent());
+    }
+
+    /**
+     * Calls the API to fetch the module list data and saves in a temporary folder. Then, checks that the data received
+     * from API is the same as the data read from storage.
+     *
+     * @throws Exception any exception that may occur.
+     */
+    @Test
+    public void saveAndReadUserModuleList_success() throws Exception {
+        Path filePath = testFolder.resolve("TempModuleSummaryList.json");
+        ModulesApi modulesApi = new ModulesApi();
+        List<ModuleCondensed> data = modulesApi.acadYearModuleListJsonGet("2022-2023");
+        JsonModuleSummaryListStorage jsonAcadYearModuleListStorage = new JsonModuleSummaryListStorage(filePath);
+
+        jsonAcadYearModuleListStorage.saveModuleSummaryList(data);
+
+        Optional<ReadOnlyModuleSummaryList> optionalReadBack = jsonAcadYearModuleListStorage
+            .readModuleSummaryList(filePath);
+        assertTrue(optionalReadBack.isPresent());
+        ReadOnlyModuleSummaryList readBack = optionalReadBack.get();
+        List<ModuleCondensed> readBackData = readBack.getModuleList();
+        assertEquals(data, readBackData);
+    }
+}

--- a/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
+++ b/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
@@ -3,6 +3,7 @@ package nus.climods.storage.module;
 import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.module.ReadOnlyModuleSummaryList;
 import nus.climods.model.module.UniqueUserModuleList;
+import nus.climods.model.module.UserModule;
 import nus.climods.storage.module.summary.JsonModuleSummaryListStorage;
 import nus.climods.storage.module.user.JsonUserModuleListStorage;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.openapitools.client.model.ModuleCondensed;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,16 +48,11 @@ class JsonUserModuleListStorageTest {
         assertFalse(readUserModuleList("NonExistentFile.json").isPresent());
     }
 
-//    @Test
-//    public void read_notJsonFormat_exceptionThrown() {
-//        assertThrows(DataConversionException.class, () -> readUserModuleList(
-//            "notJsonFormatModuleSummaryList.json"));
-//    }
-
-//    @Test
-//    public void readInvalidJsonFormat_fail() throws Exception {
-//        assertTrue(readUserModuleList("validJsonFormatModuleSummaryList.json").isEmpty());
-//    }
+    @Test
+    public void read_notJsonFormat_exceptionThrown() {
+        assertThrows(DataConversionException.class, () -> readUserModuleList(
+            "notJsonFormatModuleSummaryList.json"));
+    }
 
     @Test
     public void readValidJsonFormat_success() throws Exception {
@@ -70,18 +67,21 @@ class JsonUserModuleListStorageTest {
      */
     @Test
     public void saveAndReadUserModuleList_success() throws Exception {
-        Path filePath = testFolder.resolve("TempModuleSummaryList.json");
-        ModulesApi modulesApi = new ModulesApi();
-        List<ModuleCondensed> data = modulesApi.acadYearModuleListJsonGet("2022-2023");
-        JsonModuleSummaryListStorage jsonAcadYearModuleListStorage = new JsonModuleSummaryListStorage(filePath);
+        Path filePath = testFolder.resolve("TempUserModuleList.json");
+        UniqueUserModuleList data = new UniqueUserModuleList();
+        data.add(new UserModule("CS2103", "Friday 1400-1500", "Friday 1600-1700", "Semester 1"));
+        data.add(new UserModule("CS2030S", "Friday 1400-1500", "Monday 1600-1700", "Semester 2"));
+        data.add(new UserModule("CS2040S", "Tuesday 1400-1500", "Monday 1600-1700", "Special Term II"));
 
-        jsonAcadYearModuleListStorage.saveModuleSummaryList(data);
+        JsonUserModuleListStorage jsonUserModuleListStorage = new JsonUserModuleListStorage(filePath);
 
-        Optional<ReadOnlyModuleSummaryList> optionalReadBack = jsonAcadYearModuleListStorage
-            .readModuleSummaryList(filePath);
+        // Saving from UniqueUserList
+        jsonUserModuleListStorage.saveUserModuleList(data);
+
+        Optional<UniqueUserModuleList> optionalReadBack = jsonUserModuleListStorage
+            .readUserModuleList(filePath);
         assertTrue(optionalReadBack.isPresent());
-        ReadOnlyModuleSummaryList readBack = optionalReadBack.get();
-        List<ModuleCondensed> readBackData = readBack.getModuleList();
-        assertEquals(data, readBackData);
+        UniqueUserModuleList readBack = optionalReadBack.get();
+        assertEquals(data, readBack);
     }
 }

--- a/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
+++ b/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
@@ -1,19 +1,21 @@
 package nus.climods.storage.module;
 
+import static nus.climods.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import nus.climods.commons.exceptions.DataConversionException;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
 import nus.climods.storage.module.user.JsonUserModuleListStorage;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import java.util.Optional;
-
-import static nus.climods.testutil.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.*;
 
 class JsonUserModuleListStorageTest {
 

--- a/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
+++ b/src/test/java/nus/climods/storage/module/JsonUserModuleListStorageTest.java
@@ -1,20 +1,15 @@
 package nus.climods.storage.module;
 
 import nus.climods.commons.exceptions.DataConversionException;
-import nus.climods.model.module.ReadOnlyModuleSummaryList;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
-import nus.climods.storage.module.summary.JsonModuleSummaryListStorage;
 import nus.climods.storage.module.user.JsonUserModuleListStorage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.openapitools.client.api.ModulesApi;
-import org.openapitools.client.model.ModuleCondensed;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
+
 import java.util.Optional;
 
 import static nus.climods.testutil.Assert.assertThrows;


### PR DESCRIPTION
Closes #74 
- [x] Infrastructure Support
Infrastructure Support is added by making JsonAdapted:

1. UserModule implementation is changed. The constructor now copies the relevant fields of a Module class rather than encapsulating it. A new constructor has been written to take in relevant field values directly. There is no guarantee for Single Source of Truth for module information since it is technially possible for module information to be changed outside of the API. But shouldn't be an issue as that constructor is only used in JsonAdaptedUserModule

2. Implementation of storage related modules changed to replace AddressBook to UserModule

- [x] Update existing commands
Switch statement is used to ensure that a save operation is only triggered after a `add` or `remove` command.


- [x] Write Test Cases
Test cases test for the throwing of errors with reading of invalid json input and for saving and reading operations of the JsonUserModuleListStorage.
Similar to the test cases written by @zupey 
<img width="115" alt="Screenshot_2" src="https://user-images.githubusercontent.com/53963433/196364207-3bf90b37-67a5-4913-8eb1-dd9a5c1b103e.png">

Demo:
https://user-images.githubusercontent.com/53963433/196584633-922e7d5c-79f4-4bed-bb71-69e9839ae008.mp4



