### PR TITLE
Add prereqs command (preq)

### DIFF
--- a/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
+++ b/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
@@ -1,0 +1,23 @@
+package nus.climods.logic.commands;
+
+import nus.climods.logic.commands.exceptions.CommandException;
+import nus.climods.model.Model;
+
+public class PrereqsCommand extends Command {
+    public static final String COMMAND_WORD = "deps";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "<Module Code>: List prerequisites for a module.\n"
+            + "Example: " + COMMAND_WORD + " " + "CS2103";
+
+    private final String moduleCode;
+
+    public PrereqsCommand(String moduleCode) {
+        this.moduleCode = moduleCode;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return new CommandResult("Prerequisites for: " + moduleCode, false, false);
+    }
+}

--- a/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
+++ b/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
@@ -2,22 +2,74 @@ package nus.climods.logic.commands;
 
 import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
+import nus.climods.model.module.Module;
+import nus.climods.model.module.predicate.ModulesByCodesPredicate;
+import org.openapitools.client.ApiException;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Lists prerequisites for a module.
+ */
 public class PrereqsCommand extends Command {
     public static final String COMMAND_WORD = "deps";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + "<Module Code>: List prerequisites for a module.\n"
             + "Example: " + COMMAND_WORD + " " + "CS2103";
-
+    public static final String MESSAGE_MODULE_NOT_FOUND = "Module '%s' not in current NUS curriculum";
+    public static final String MESSAGE_MODULE_LOAD_ERROR = "Error loading prerequisites for %s";
+    public static final String MESSAGE_MODULE_NO_PREREQUISITES = "Module %s has no prerequisites";
+    public static final String MESSAGE_SUCCESS = "Showing available prerequisites for %s";
+    /**
+     * Pattern to extract module codes from a string
+     */
+    private static final Pattern MODULE_CODE_EXTRACT_PATTERN = Pattern.compile("[A-Z]{2,4}\\d{4}[A-Z]{0,5}\\d{0,2}");
     private final String moduleCode;
 
+    /**
+     * Constructor for PrereqsCommand class
+     * @param moduleCode Module code to list prerequisites for
+     */
     public PrereqsCommand(String moduleCode) {
-        this.moduleCode = moduleCode;
+        Objects.requireNonNull(moduleCode);
+        this.moduleCode = moduleCode.toUpperCase().trim();
     }
 
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult("Prerequisites for: " + moduleCode, false, false);
+        Optional<Module> moduleOptional = model.getListModule(moduleCode);
+
+        if (moduleOptional.isEmpty()) {
+            return new CommandResult(String.format(MESSAGE_MODULE_NOT_FOUND, moduleCode), false, false);
+        }
+
+        Module module = moduleOptional.get();
+        try {
+            module.loadMoreData();
+        } catch (ApiException e) {
+            throw new CommandException(String.format(MESSAGE_MODULE_LOAD_ERROR, moduleCode));
+        }
+        String prereqString = module.getPrerequisite();
+
+        if (prereqString == null) {
+            return new CommandResult(String.format(MESSAGE_MODULE_NO_PREREQUISITES, moduleCode), false, false);
+        }
+        Matcher matcher = MODULE_CODE_EXTRACT_PATTERN.matcher(prereqString);
+        List<String> prereqs = matcher.results().map(MatchResult::group).collect(Collectors.toList());
+
+        // e.g classes where prerequisite is a String describing O Level or A Level qualifications
+        if (prereqs.size() == 0) {
+            return new CommandResult(String.format(MESSAGE_MODULE_NO_PREREQUISITES, moduleCode), false, false);
+        }
+        model.showModules(prereqs);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, moduleCode), false, false);
     }
 }

--- a/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
+++ b/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * Lists prerequisites for a module.
  */
 public class PrereqsCommand extends Command {
-    public static final String COMMAND_WORD = "deps";
+    public static final String COMMAND_WORD = "preq";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + "<Module Code>: List prerequisites for a module.\n"
             + "Example: " + COMMAND_WORD + " " + "CS2103";

--- a/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
+++ b/src/main/java/nus/climods/logic/commands/PrereqsCommand.java
@@ -14,8 +14,6 @@ import nus.climods.logic.commands.exceptions.CommandException;
 import nus.climods.model.Model;
 import nus.climods.model.module.Module;
 
-
-
 /**
  * Lists prerequisites for a module.
  */

--- a/src/main/java/nus/climods/logic/parser/CliModsParser.java
+++ b/src/main/java/nus/climods/logic/parser/CliModsParser.java
@@ -13,6 +13,7 @@ import nus.climods.logic.commands.ExitCommand;
 import nus.climods.logic.commands.FindCommand;
 import nus.climods.logic.commands.HelpCommand;
 import nus.climods.logic.commands.ListCommand;
+import nus.climods.logic.commands.PrereqsCommand;
 import nus.climods.logic.commands.ViewCommand;
 import nus.climods.logic.parser.exceptions.ParseException;
 
@@ -57,6 +58,8 @@ public class CliModsParser {
             return new HelpCommandParser().parse(arguments);
         case (ViewCommand.COMMAND_WORD):
             return new ViewCommandParser().parse(arguments);
+        case (PrereqsCommand.COMMAND_WORD):
+            return new PrereqsCommandParser().parse(arguments);
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/nus/climods/logic/parser/PrereqsCommandParser.java
+++ b/src/main/java/nus/climods/logic/parser/PrereqsCommandParser.java
@@ -1,0 +1,14 @@
+package nus.climods.logic.parser;
+
+import nus.climods.logic.commands.PrereqsCommand;
+import nus.climods.logic.parser.exceptions.ParseException;
+import nus.climods.logic.parser.parameters.ModuleCodeParameter;
+
+public class PrereqsCommandParser implements Parser<PrereqsCommand> {
+    @Override
+    public PrereqsCommand parse(String args) throws ParseException {
+        ModuleCodeParameter mcp = new ModuleCodeParameter(args);
+        String moduleCode = mcp.getArgValue();
+        return new PrereqsCommand(moduleCode);
+    }
+}

--- a/src/main/java/nus/climods/logic/parser/PrereqsCommandParser.java
+++ b/src/main/java/nus/climods/logic/parser/PrereqsCommandParser.java
@@ -4,6 +4,9 @@ import nus.climods.logic.commands.PrereqsCommand;
 import nus.climods.logic.parser.exceptions.ParseException;
 import nus.climods.logic.parser.parameters.ModuleCodeParameter;
 
+/**
+ * Parses input arguments and creates new PrereqsCommand
+ */
 public class PrereqsCommandParser implements Parser<PrereqsCommand> {
     @Override
     public PrereqsCommand parse(String args) throws ParseException {

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -70,10 +70,12 @@ public interface Model {
     void setModuleInFocus(Module module) throws ApiException;
 
     /**
-     * Show modules specified in moduleCodes list
+     * Show modules specified in moduleCodes list. If no module codes are in the current curriculum,
+     *      showModules returns false and does not show any new modules.
      * @param moduleCodes List of module codes specifying modules to show
+     * @return true if at least one of the given module codes is a valid module in current curriculum
      */
-    void showModules(List<String> moduleCodes);
+    boolean showModules(List<String> moduleCodes);
 
     /**
      * Resets active module to be inactive

--- a/src/main/java/nus/climods/model/Model.java
+++ b/src/main/java/nus/climods/model/Model.java
@@ -1,6 +1,7 @@
 package nus.climods.model;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -67,6 +68,12 @@ public interface Model {
      * Sets module (currently for view) in full module list to the module specified by moduleCode
      */
     void setModuleInFocus(Module module) throws ApiException;
+
+    /**
+     * Show modules specified in moduleCodes list
+     * @param moduleCodes List of module codes specifying modules to show
+     */
+    void showModules(List<String> moduleCodes);
 
     /**
      * Resets active module to be inactive

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import nus.climods.model.module.predicate.ModulesByCodesPredicate;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.model.SemestersEnum;
 
@@ -23,7 +22,9 @@ import nus.climods.model.module.ModuleList;
 import nus.climods.model.module.ReadOnlyModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
+import nus.climods.model.module.predicate.ModulesByCodesPredicate;
 import nus.climods.model.module.predicate.ViewModulePredicate;
+
 
 /**
  * Represents the in-memory model of module list data.
@@ -126,8 +127,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void showModules(List<String> moduleCodes) {
+    public boolean showModules(List<String> moduleCodes) {
+        long validCodes = moduleCodes.stream().filter(this::isModuleOffered).count();
+        if (validCodes == 0) {
+            return false;
+        }
         this.setFilteredModuleList(new ModulesByCodesPredicate(moduleCodes));
+        return true;
     }
 
     @Override

--- a/src/main/java/nus/climods/model/ModelManager.java
+++ b/src/main/java/nus/climods/model/ModelManager.java
@@ -4,10 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static nus.climods.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import nus.climods.model.module.predicate.ModulesByCodesPredicate;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.model.SemestersEnum;
 
@@ -121,6 +123,11 @@ public class ModelManager implements Model {
         moduleInFocus = module;
 
         setFilteredModuleList(new ViewModulePredicate(module.getCode()));
+    }
+
+    @Override
+    public void showModules(List<String> moduleCodes) {
+        this.setFilteredModuleList(new ModulesByCodesPredicate(moduleCodes));
     }
 
     @Override

--- a/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
+++ b/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
@@ -1,0 +1,2 @@
+package nus.climods.model.module.predicate;public class ModulesByCodesPredicate {
+}

--- a/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
+++ b/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
@@ -1,15 +1,15 @@
 package nus.climods.model.module.predicate;
 
-import nus.climods.model.module.Module;
-
 import java.util.List;
 import java.util.function.Predicate;
 
+import nus.climods.model.module.Module;
+
 /**
- * Tests that a {@Module's code} matches one of the supplied codes
+ * Tests that a Module's code matches one of the supplied codes
  */
 public class ModulesByCodesPredicate implements Predicate<Module> {
-    private List<String> moduleCodes;
+    private final List<String> moduleCodes;
 
     public ModulesByCodesPredicate(List<String> moduleCodes) {
         this.moduleCodes = moduleCodes;

--- a/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
+++ b/src/main/java/nus/climods/model/module/predicate/ModulesByCodesPredicate.java
@@ -1,2 +1,22 @@
-package nus.climods.model.module.predicate;public class ModulesByCodesPredicate {
+package nus.climods.model.module.predicate;
+
+import nus.climods.model.module.Module;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@Module's code} matches one of the supplied codes
+ */
+public class ModulesByCodesPredicate implements Predicate<Module> {
+    private List<String> moduleCodes;
+
+    public ModulesByCodesPredicate(List<String> moduleCodes) {
+        this.moduleCodes = moduleCodes;
+    }
+
+    @Override
+    public boolean test(Module module) {
+        return moduleCodes.contains(module.getCode());
+    }
 }

--- a/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
@@ -71,6 +71,4 @@ public class PrereqsCommandTest {
             throw new RuntimeException(e);
         }
     }
-
-
 }

--- a/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
@@ -1,0 +1,2 @@
+package nus.climods.logic.commands;public class PrereqsCommandTest {
+}

--- a/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/PrereqsCommandTest.java
@@ -1,2 +1,76 @@
-package nus.climods.logic.commands;public class PrereqsCommandTest {
+package nus.climods.logic.commands;
+
+import static nus.climods.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import nus.climods.logic.commands.exceptions.CommandException;
+import nus.climods.model.Model;
+import nus.climods.model.ModelManager;
+import nus.climods.model.UserPrefs;
+import nus.climods.model.module.Module;
+import nus.climods.model.module.ModuleList;
+import nus.climods.model.module.UniqueUserModuleList;
+
+public class PrereqsCommandTest {
+    private static final String testAcademicYear = "2022-2023";
+    private static final String INVALID_CODE = "CS9999";
+    private static final String VALID_CODE_NULL_PREQ = "AC5001";
+    private static final String VALID_CODE_PREQ_NO_MODULES = "MA1301X";
+    private static final String VALID_CODE_HAS_MODULES = "CS2106";
+    private final Model model = new ModelManager(new ModuleList(testAcademicYear), new UniqueUserModuleList(),
+            new UserPrefs());
+
+    @Test
+    public void execute_moduleCodeNotValid_throwsException() {
+        PrereqsCommand cmd = new PrereqsCommand(INVALID_CODE);
+        assertThrows(CommandException.class,
+                String.format(PrereqsCommand.MESSAGE_MODULE_NOT_FOUND, INVALID_CODE), () -> cmd.execute(model));
+    }
+
+    @Test
+    public void execute_prereqIsNull_returnsNoPrereqMessage() {
+        PrereqsCommand cmd = new PrereqsCommand(VALID_CODE_NULL_PREQ);
+        try {
+            CommandResult res = cmd.execute(model);
+            Assertions.assertEquals(String.format(PrereqsCommand.MESSAGE_MODULE_NO_PREREQUISITES,
+                    VALID_CODE_NULL_PREQ), res.getFeedbackToUser());
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void execute_prereqNoValidModules_returnsNoPrereqMessage() {
+        PrereqsCommand cmd = new PrereqsCommand(VALID_CODE_PREQ_NO_MODULES);
+        try {
+            CommandResult res = cmd.execute(model);
+            Assertions.assertEquals(String.format(PrereqsCommand.MESSAGE_MODULE_NO_PREREQUISITES,
+                    VALID_CODE_PREQ_NO_MODULES), res.getFeedbackToUser());
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void execute_prereqHasValidModules_returnsSuccess() {
+        PrereqsCommand cmd = new PrereqsCommand(VALID_CODE_HAS_MODULES);
+        try {
+            CommandResult res = cmd.execute(model);
+            Assertions.assertEquals(String.format(PrereqsCommand.MESSAGE_SUCCESS,
+                    VALID_CODE_HAS_MODULES), res.getFeedbackToUser());
+            List<String> codes = model.getFilteredModuleList()
+                    .stream().map(Module::getCode).collect(Collectors.toList());
+            Assertions.assertEquals(codes, Arrays.asList("CS2100", "EE2024", "EE2028"));
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
 }


### PR DESCRIPTION
#40 
Usage: `preq <module-code>`
e.g `preq CS2106`

I decided not to use the `PrereqTree` class to get prerequisites because it seemed buggy with some modules. For example:
- CS3230: could only get an empty object from `PrereqTreeOneOf`
- CS2103: shows CS1020 and CS2020 but not CS2030, CS2040

Instead, I used a regex (in `PrereqsCommand`) to extract module codes from the prerequisite string if it exists then used that to request `Model` to show the module codes if they exist. This also means what the user sees from the command matches with the prerequisite string seen after calling `view`

Current issues:
- Some module codes such as CS1020 and CS2020 are quite common but refer to older modules from different academic years, so nothing will be shown for those after calling `preq`. 
    - A hacky solution could be to store mappings for old codes to the current academic year. To really ensure correctness we would have to check past academic years using the API
- `preq` will just filter the list to all valid module codes in the prerequisite string, but the user won’t be able to see and/or relationships at that point.