### PR TITLE
Fix PickCommand bug

### DIFF
--- a/src/main/java/nus/climods/logic/commands/PickCommand.java
+++ b/src/main/java/nus/climods/logic/commands/PickCommand.java
@@ -26,7 +26,7 @@ public class PickCommand extends Command {
     public static final String MESSAGE_MODULE_MISSING = "This module is not in your module list";
     public static final String MESSAGE_INVALID_LESSON_TYPE = "This lesson type is not offered in this module";
     public static final String MESSAGE_INVALID_LESSON_ID = "This class is not offered or an invalid one";
-    public static final String MESSAGE_DUPLICATE_LESSON_ID = "This class already exist in your current module";
+    public static final String MESSAGE_PICK_UNSELECTABLE_LESSON = "This lesson timing is fixed and cannot be picked";
 
     private final String toPick;
     private final LessonTypeEnum lessonType;
@@ -60,6 +60,11 @@ public class PickCommand extends Command {
             module.loadMoreData();
         } catch (ApiException e) {
             throw new CommandException("Error 404 something went wrong");
+        }
+
+        //check if lesson class code is unselectable
+        if (module.getUnselectableLessonTypeEnums(curr.getSelectedSemester()).contains(lessonType)) {
+            throw new CommandException(MESSAGE_PICK_UNSELECTABLE_LESSON);
         }
 
         //check if lesson type is offered

--- a/src/main/java/nus/climods/logic/parser/PickCommandParser.java
+++ b/src/main/java/nus/climods/logic/parser/PickCommandParser.java
@@ -30,7 +30,7 @@ public class PickCommandParser implements Parser<PickCommand> {
         LessonTypeParameter ltp = new LessonTypeParameter(args);
         LessonTypeEnum lt = ltp.getArgValue();
 
-        String classNo = arg[3].trim();
+        String classNo = arg[3].trim().toUpperCase();
 
         return new PickCommand(mc, lt, classNo);
     }

--- a/src/main/java/nus/climods/model/module/Module.java
+++ b/src/main/java/nus/climods/model/module/Module.java
@@ -265,8 +265,6 @@ public class Module {
      */
     public HashMap<LessonTypeEnum, ModuleLessonIdMap> getLessons(SemestersEnum semester) {
         requireNonNull(lessonMap);
-        assert lessonMap.containsKey(semester);
-
         return lessonMap.get(semester);
     }
 

--- a/src/test/java/nus/climods/logic/commands/PickCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/PickCommandTest.java
@@ -3,6 +3,7 @@ package nus.climods.logic.commands;
 import static nus.climods.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.SemestersEnum;
 
@@ -15,10 +16,14 @@ import nus.climods.model.module.ModuleList;
 import nus.climods.model.module.UniqueUserModuleList;
 import nus.climods.model.module.UserModule;
 
+
 public class PickCommandTest {
     private static final String testAcademicYear = "2022-2023";
     private final Model model = new ModelManager(new ModuleList(testAcademicYear), new UniqueUserModuleList(),
             new UserPrefs());
+    private void addCS1010J() {
+        model.addUserModule(new UserModule("CS1010J", SemestersEnum.S1));
+    }
 
     /**
      * Null module throws exception.
@@ -35,8 +40,7 @@ public class PickCommandTest {
     @Test
     public void execute_pick_success() throws CommandException {
         String expectedMessage = String.format(PickCommand.MESSAGE_SUCCESS, "CS1010J TUT 02");
-        model.addUserModule(new UserModule("CS1010J", SemestersEnum.S1));
-
+        addCS1010J();
         PickCommand pickCommand = new PickCommand("CS1010J", LessonTypeEnum.TUT, "02");
         CommandResult commandResult = pickCommand.execute(model);
 
@@ -44,25 +48,25 @@ public class PickCommandTest {
     }
 
     /**
-     * CS1010J is not offered in Semester 2.
+     * Recitations not offered in CS1010J
      * @throws CommandException
      */
     @Test
     public void execute_addLessonTypeNotOfferedInSemester_throwsException() {
         PickCommand pickCommand = new PickCommand("CS1010J", LessonTypeEnum.REC, "15");
-
-        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+        addCS1010J();
+        assertThrows(CommandException.class, PickCommand.MESSAGE_INVALID_LESSON_TYPE, () -> pickCommand.execute(model));
     }
 
     /**
-     * CS1010J is not offered in Semester 2.
+     * Tut 15 not a valid tutorial for CS1010J
      * @throws CommandException
      */
     @Test
     public void execute_addLessonIdNotOfferedInSemester_throwsException() {
         PickCommand pickCommand = new PickCommand("CS1010J", LessonTypeEnum.TUT, "15");
-
-        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+        addCS1010J();
+        assertThrows(CommandException.class, PickCommand.MESSAGE_INVALID_LESSON_ID, () -> pickCommand.execute(model));
     }
 
     /**
@@ -72,8 +76,9 @@ public class PickCommandTest {
     @Test
     public void execute_addLessonIdUnpickable_throwsException() {
         PickCommand pickCommand = new PickCommand("CS1010J", LessonTypeEnum.LEC, "15");
-
-        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+        addCS1010J();
+        assertThrows(CommandException.class, PickCommand.MESSAGE_PICK_UNSELECTABLE_LESSON, ()
+                -> pickCommand.execute(model));
     }
 
     /**
@@ -84,7 +89,19 @@ public class PickCommandTest {
     public void execute_pickLessonForMissingModule_throwsException() {
         PickCommand pickCommand = new PickCommand("CS2100", LessonTypeEnum.TUT, "15");
 
-        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+        assertThrows(CommandException.class, PickCommand.MESSAGE_MODULE_MISSING, () -> pickCommand.execute(model));
+    }
+
+    /**
+     * Tests that both lab and tutorial can be added
+     */
+    @Test
+    public void execute_addLabAndTutorial_success() {
+        PickCommand addLab = new PickCommand("CS2100", LessonTypeEnum.LAB, "01");
+        PickCommand addTutorial = new PickCommand("CS2100", LessonTypeEnum.TUT, "02");
+        model.addUserModule(new UserModule("CS2100", SemestersEnum.S1));
+        Assertions.assertDoesNotThrow(() -> addLab.execute(model));
+        Assertions.assertDoesNotThrow(() -> addTutorial.execute(model));
     }
 
 }

--- a/src/test/java/nus/climods/logic/commands/PickCommandTest.java
+++ b/src/test/java/nus/climods/logic/commands/PickCommandTest.java
@@ -20,11 +20,18 @@ public class PickCommandTest {
     private final Model model = new ModelManager(new ModuleList(testAcademicYear), new UniqueUserModuleList(),
             new UserPrefs());
 
+    /**
+     * Null module throws exception.
+     */
     @Test
     public void construct_nullModule_throwsException() {
         assertThrows(NullPointerException.class, () -> new PickCommand(null, null, null));
     }
 
+    /**
+     * Successful execution of PickCommand.
+     * @throws CommandException
+     */
     @Test
     public void execute_pick_success() throws CommandException {
         String expectedMessage = String.format(PickCommand.MESSAGE_SUCCESS, "CS1010J TUT 02");
@@ -57,4 +64,27 @@ public class PickCommandTest {
 
         assertThrows(CommandException.class, () -> pickCommand.execute(model));
     }
+
+    /**
+     * Lecture is unpickable for cs1010j.
+     * @throws CommandException
+     */
+    @Test
+    public void execute_addLessonIdUnpickable_throwsException() {
+        PickCommand pickCommand = new PickCommand("CS1010J", LessonTypeEnum.LEC, "15");
+
+        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+    }
+
+    /**
+     * Missing module.
+     * @throws CommandException
+     */
+    @Test
+    public void execute_pickLessonForMissingModule_throwsException() {
+        PickCommand pickCommand = new PickCommand("CS2100", LessonTypeEnum.TUT, "15");
+
+        assertThrows(CommandException.class, () -> pickCommand.execute(model));
+    }
+
 }

--- a/src/test/java/nus/climods/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/nus/climods/logic/parser/AddCommandParserTest.java
@@ -52,7 +52,7 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_moduleNotOfferedInSemesterType_throwsParseException() {
+    public void parse_addCommandSuccess() {
         AddCommand expectedAddCommand = new AddCommand("CS1010J", SemestersEnum.S1);
 
         String input = "CS1010J s1";

--- a/src/test/java/nus/climods/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/nus/climods/logic/parser/AddCommandParserTest.java
@@ -1,11 +1,14 @@
 package nus.climods.logic.parser;
 
 import static nus.climods.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static nus.climods.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
+import org.openapitools.client.model.SemestersEnum;
 
+import nus.climods.logic.commands.AddCommand;
 import nus.climods.logic.parser.parameters.ModuleCodeParameter;
-
+import nus.climods.logic.parser.parameters.SemesterTypeParameter;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
@@ -23,18 +26,36 @@ public class AddCommandParserTest {
     @Test
     public void parse_invalidFormatTextOnly_throwsParseException() {
         String input = "CSFASS";
+
         assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, input));
     }
 
     @Test
     public void parse_invalidFormatNumFirst_throwsParseException() {
         String input = "210ergerg";
+
         assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, input));
     }
 
     @Test
     public void parse_invalidFormatNotEnoughNumber_throwsParseException() {
         String input = "CS210";
+
         assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, input));
+    }
+
+    @Test
+    public void parse_invalidFormatSemesterType_throwsParseException() {
+        String input = "CS2100 k1";
+
+        assertParseFailure(parser, input, String.format(SemesterTypeParameter.PARSE_EXCEPTION_MESSAGE, "k1"));
+    }
+
+    @Test
+    public void parse_moduleNotOfferedInSemesterType_throwsParseException() {
+        AddCommand expectedAddCommand = new AddCommand("CS1010J", SemestersEnum.S1);
+
+        String input = "CS1010J s1";
+        assertParseSuccess(parser, input, expectedAddCommand);
     }
 }

--- a/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
+++ b/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
@@ -1,0 +1,69 @@
+package nus.climods.logic.parser;
+
+import static nus.climods.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static nus.climods.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import nus.climods.logic.commands.PickCommand;
+import nus.climods.logic.parser.parameters.LessonTypeParameter;
+import nus.climods.logic.parser.parameters.ModuleCodeParameter;
+import nus.climods.model.module.LessonTypeEnum;
+
+public class PickCommandParserTest {
+    private PickCommandParser parser = new PickCommandParser();
+
+    @Test
+    public void parse_emptyInput_throwsParseException() {
+        assertParseFailure(parser, "", "You need 3 arguments: <module-code> <lesson-type> <classNo>");
+    }
+
+    @Test
+    public void parse_blankInput_throwsParseException() {
+        assertParseFailure(parser, "   ", ModuleCodeParameter.INVALID_INPUT_MESSAGE);
+    }
+
+    @Test
+    public void parse_invalidFormatTextOnly_throwsParseException() {
+        String input = "CSFASS lol 999 ";
+
+        assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, "CSFASS"));
+    }
+
+    @Test
+    public void parse_invalidFormatNumFirst_throwsParseException() {
+        String input = "210ergerg lol 999 ";
+
+        assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, "210ergerg"));
+    }
+
+    @Test
+    public void parse_invalidFormatNotEnoughNumber_throwsParseException() {
+        String input = "CS210 lol 999 ";
+
+        assertParseFailure(parser, input, String.format(ModuleCodeParameter.PARSE_EXCEPTION_MESSAGE, "CS210"));
+    }
+
+    @Test
+    public void parse_invalidFormatLessonType_throwsParseException() {
+        String input = "CS2100 lol 999 ";
+
+        assertParseFailure(parser, input, String.format(LessonTypeParameter.PARSE_EXCEPTION_MESSAGE, "lol"));
+    }
+
+    @Test
+    public void parse_insufficientArguments_throwsParseException() {
+        String input = "CS2100 ";
+
+        assertParseFailure(parser, input, "You need 3 arguments: <module-code> <lesson-type> <classNo>");
+    }
+
+
+    @Test
+    public void parse_pickCommandSuccess() {
+        PickCommand expectedPickCommand = new PickCommand("CS1010J", LessonTypeEnum.TUT, "02");
+
+        String input = "CS1010J TUT 02 ";
+        assertParseSuccess(parser, input, expectedPickCommand);
+    }
+}


### PR DESCRIPTION
- [x] Ensure case insensitivity
- [x] Throw correct error message when user tries to pick an unselectable lesson
- [x] Add test cases for PickCommand
- [x] Add test cases for PickCommand Parser

Note
----
With regards to displaying an error message when users keyboard spam after their command, I think we can fix it by tweaking the parser such that users cannot keyboard spam after typing any of our commands.