### PR TITLE
Fix `pickcommand` bug that cannot pick valid lesson

### DIFF
--- a/src/main/java/nus/climods/logic/parser/ParserUtil.java
+++ b/src/main/java/nus/climods/logic/parser/ParserUtil.java
@@ -106,11 +106,8 @@ public class ParserUtil {
 
         LessonTypeEnum s1 = LessonTypeEnum.fromName(toCheck);
 
-        if (!s1.equals(LessonTypeEnum.UNSUPPORTED)) {
-            return Optional.of(s1);
-        }
+        return Optional.of(s1);
 
-        return Optional.empty();
     }
     /**
      * Parse semester details according to user input

--- a/src/main/java/nus/climods/model/module/LessonTypeEnum.java
+++ b/src/main/java/nus/climods/model/module/LessonTypeEnum.java
@@ -11,7 +11,7 @@ public enum LessonTypeEnum {
     LAB("Laboratory"),
     REC("Recitation"),
     SEC("Sectional Teaching"),
-    UNSUPPORTED("");
+    OTHERS("Others");
 
     private final String valueStr;
 
@@ -37,7 +37,7 @@ public enum LessonTypeEnum {
             }
         }
 
-        return LessonTypeEnum.UNSUPPORTED;
+        return LessonTypeEnum.OTHERS;
     }
 
     /**
@@ -54,7 +54,7 @@ public enum LessonTypeEnum {
             }
         }
 
-        return LessonTypeEnum.UNSUPPORTED;
+        return LessonTypeEnum.OTHERS;
     }
 
     @Override

--- a/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
+++ b/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
@@ -45,13 +45,6 @@ public class PickCommandParserTest {
     }
 
     @Test
-    public void parse_invalidFormatLessonType_throwsParseException() {
-        String input = "CS2100 lol 999 ";
-
-        assertParseFailure(parser, input, String.format(LessonTypeParameter.PARSE_EXCEPTION_MESSAGE, "lol"));
-    }
-
-    @Test
     public void parse_insufficientArguments_throwsParseException() {
         String input = "CS2100 ";
 

--- a/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
+++ b/src/test/java/nus/climods/logic/parser/PickCommandParserTest.java
@@ -6,7 +6,6 @@ import static nus.climods.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import org.junit.jupiter.api.Test;
 
 import nus.climods.logic.commands.PickCommand;
-import nus.climods.logic.parser.parameters.LessonTypeParameter;
 import nus.climods.logic.parser.parameters.ModuleCodeParameter;
 import nus.climods.model.module.LessonTypeEnum;
 


### PR DESCRIPTION
Try adding pls8001, and we cannot add an unsupported lesson type.

Lets fix this bug!